### PR TITLE
Beta4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Current Limitations (expected to be lifted in subsequent versions):
 - Baseline semantic rulesets (Schematron) may be incomplete
 - TM does not support external Schematron rulesets
 - JSON Schema Validation of Voter Records Interchange (VRI) is not supported
-- JSON Schema Validation of certain Election Event Logs may fail
-- There is a known issue with the JSON Schema Validator's handling of `format: time` for certain format models
 
 > NB: Voter Records Interchange does not have any interoperability requirements in VVSG 2.0
 

--- a/pipelines/consolidate_reports.xpl
+++ b/pipelines/consolidate_reports.xpl
@@ -14,7 +14,7 @@
         <p:with-input port="insertion">
             <p:inline>
                 <xvrl:metadata xmlns:xvrl="http://www.xproc.org/ns/xvrl">
-                    <xvrl:creator name="NIST Common Data Format Test Method" version="1.0.0beta3" />
+                    <xvrl:creator name="NIST Common Data Format Test Method" version="1.0.0beta4" />
                     <xvrl:timestamp>{$start-dateTime}</xvrl:timestamp>
                     <xvrl:summary>Please review each report to determine conformance to the applicable test assertions / requirements</xvrl:summary>
                     <xvrl:supplemental tm:xproc-engine-name="{p:system-property('p:product-name')}"

--- a/pipelines/validate_eel_xml.xpl
+++ b/pipelines/validate_eel_xml.xpl
@@ -20,11 +20,10 @@
     later -->
     <p:if test="exists(/*/@xsi:schemaLocation)"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <p:variable name="current-document" select="document-uri(.)"></p:variable>
         <p:error code="tm:schemaLocationNotAllowed">
             <p:with-input port="source">
                 <message>Attribute xsi:schemaLocation on root tag is disallowed for
-                    {$current-document}.</message>
+                    {p:document-property(.,'base-uri')}.</message>
             </p:with-input>
         </p:error>
     </p:if>
@@ -41,7 +40,7 @@
         <p:error code="tm:badtag">
             <p:with-input port="source">
                 <message>The input document root tag is unexpected. Expected "ElectionEventLog" for
-                    {document-uri()}</message>
+                    {p:document-property(.,'base-uri')}</message>
             </p:with-input>
         </p:error>
     </p:if>
@@ -62,7 +61,7 @@
         <p:error code="tm:schemaLocationNotAllowed">
             <p:with-input port="source">
                 <message>Attribute xsi:schemaLocation on root tag is disallowed for
-                    {$current-document}.</message>
+                    {p:document-property(.,'base-uri')}.</message>
             </p:with-input>
         </p:error>
     </p:if>
@@ -71,7 +70,7 @@
         <p:error code="tm:badtag">
             <p:with-input port="source">
                 <message>The input document root tag is unexpected. Expected
-                    "ElectionEventLogDocumentation" for {document-uri()}.</message>
+                    "ElectionEventLogDocumentation" for {p:document-property(.,'base-uri')}.</message>
             </p:with-input>
         </p:error>
     </p:if>

--- a/pipelines/validate_xml.xpl
+++ b/pipelines/validate_xml.xpl
@@ -16,11 +16,10 @@
     later -->
     <p:if test="exists(/*/@xsi:schemaLocation)"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <p:variable name="current-document" select="document-uri(.)"></p:variable>
         <p:error code="tm:schemaLocationNotAllowed">
             <p:with-input port="source">
                 <message>Attribute xsi:schemaLocation on root tag is disallowed for
-                    {$current-document}.</message>
+                    {p:document-property(.,'base-uri')}.</message>
             </p:with-input>
         </p:error>
     </p:if>

--- a/resources/bd_v1/bd_v1_sua.sch
+++ b/resources/bd_v1/bd_v1_sua.sch
@@ -4,7 +4,7 @@
     <xsl:key name="Party" match="/cdf:BallotDefinition/cdf:Party" use="@ObjectId"/>
     <xsl:key name="Person" match="/cdf:BallotDefinition/cdf:Person" use="@ObjectId"/>
     <xsl:key name="Election" match="/cdf:BallotDefinition/cdf:Election" use="@ObjectId"/>
-    <xsl:key name="ReportingUnit" match="/cdf:BallotDefinition/cdf:GpUnit[@xsi:type = 'cdf:ReportingUnit']" use="@ObjectId"/>
+    <xsl:key name="ReportingUnit" match="/cdf:BallotDefinition/cdf:GpUnit[contains(@xsi:type, 'ReportingUnit')]" use="@ObjectId"/>
     <xsl:key name="GpUnit" match="/cdf:BallotDefinition/cdf:GpUnit" use="@ObjectId"/>
     <xsl:key name="BallotFormat" match="/cdf:BallotDefinition/cdf:BallotFormat" use="@ObjectId"/>
     <xsl:key name="Office" match="/cdf:BallotDefinition/cdf:Office" use="@ObjectId"/>

--- a/resources/bd_v1/bd_v1_sua.sch
+++ b/resources/bd_v1/bd_v1_sua.sch
@@ -1,78 +1,99 @@
-<?xml version="1.0" encoding="UTF-8"?><sch:schema xmlns:mp="http://mapping" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">    
-    <sch:ns uri="http://itl.nist.gov/ns/voting/1500-20/v1" prefix="cdf"/>
-    <sch:ns uri="http://itl.nist.gov/ns/voting/1500-20/v1" prefix="err"/>        
-    <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>            
-    <sch:pattern>
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:mp="http://mapping" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+    <xsl:key name="ContestOption" match="/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption" use="@ObjectId"/>
+    <xsl:key name="Party" match="/cdf:BallotDefinition/cdf:Party" use="@ObjectId"/>
+    <xsl:key name="Person" match="/cdf:BallotDefinition/cdf:Person" use="@ObjectId"/>
+    <xsl:key name="Election" match="/cdf:BallotDefinition/cdf:Election" use="@ObjectId"/>
+    <xsl:key name="ReportingUnit" match="/cdf:BallotDefinition/cdf:GpUnit[@xsi:type = 'cdf:ReportingUnit']" use="@ObjectId"/>
+    <xsl:key name="GpUnit" match="/cdf:BallotDefinition/cdf:GpUnit" use="@ObjectId"/>
+    <xsl:key name="BallotFormat" match="/cdf:BallotDefinition/cdf:BallotFormat" use="@ObjectId"/>
+    <xsl:key name="Office" match="/cdf:BallotDefinition/cdf:Office" use="@ObjectId"/>
+    <xsl:key name="Contest" match="/cdf:BallotDefinition/cdf:Election/cdf:Contest" use="@ObjectId"/>
+    <xsl:key name="Candidate" match="/cdf:BallotDefinition/cdf:Election/cdf:Candidate" use="@ObjectId"/>
+    <xsl:key name="Header" match="/cdf:BallotDefinition/cdf:Header" use="@ObjectId"/>
+    <xsl:key name="Shape" match="/cdf:BallotDefinition/cdf:Shape" use="@ObjectId"/>    
+    <sch:ns uri="http://itl.nist.gov/ns/voting/1500-20/v1" prefix="cdf"/>    
+    <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>
+    <sch:pattern>        
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:PhysicalContestOption)">
-            <sch:assert test="not(err:ContestOptionId) or count([@ObjectId = current()/err:ContestOptionId]) = 1">) ContestOptionId (<sch:value-of select="cdf:ContestOptionId"/>) must point to an element of type ContestOption</sch:assert>
-        </sch:rule>
+            <sch:assert test="not(cdf:ContestOptionId) or key('ContestOption',current()/cdf:ContestOptionId)">) ContestOptionId (<sch:value-of select="cdf:ContestOptionId"/> must point to an element of type ContestOption</sch:assert>
+        </sch:rule>        
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Candidate)">
-            <sch:assert test="not(err:PartyId) or count(/cdf:BallotDefinition/cdf:Party[@ObjectId = current()/err:PartyId]) = 1">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(err:PersonId) or count(/cdf:BallotDefinition/cdf:Person[@ObjectId = current()/err:PersonId]) = 1">) PersonId (<sch:value-of select="cdf:PersonId"/>) must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)">) PersonId (<sch:value-of select="cdf:PersonId"/> must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Person)">
-            <sch:assert test="not(err:PartyId) or count(/cdf:BallotDefinition/cdf:Party[@ObjectId = current()/err:PartyId]) = 1">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Office)">
-            <sch:assert test="not(err:OfficeHolderPersonIds) or (every $curId in tokenize(err:OfficeHolderPersonIds) satisfies /cdf:BallotDefinition/cdf:Person[@ObjectId = $curId])">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/>) must point to an element of type Person</sch:assert>
-            <sch:assert test="not(err:ElectionDistrictId) or count(/cdf:BallotDefinition/cdf:GpUnit[@ObjectId = current()/err:ElectionDistrictId]) = 1">) ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/>) must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:OfficeHolderPersonIds) or (every $curId in tokenize(cdf:OfficeHolderPersonIds) satisfies key('Person',$curId))">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/> must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)">) ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/> must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit/cdf:ElectionAdministration)">
-            <sch:assert test="not(err:ElectionOfficialPersonIds) or (every $curId in tokenize(err:ElectionOfficialPersonIds) satisfies /cdf:BallotDefinition/cdf:Person[@ObjectId = $curId])">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/>) must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:ElectionOfficialPersonIds) or (every $curId in tokenize(cdf:ElectionOfficialPersonIds) satisfies key('Person',$curId))">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/> must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit/cdf:PartyRegistration)">
-            <sch:assert test="not(err:PartyId) or count(/cdf:BallotDefinition/cdf:Party[@ObjectId = current()/err:PartyId]) = 1">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Party)">            
-            <sch:assert test="not(err:LeaderPersonIds) or (every $curId in tokenize(err:LeaderPersonIds) satisfies /cdf:BallotDefinition/cdf:Person[@ObjectId = $curId])">LeaderPersonIds (<sch:value-of select="cdf:LeaderPersonIds"/>) must point to an element of type Person</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Party)">
+            <sch:assert test="not(cdf:PartyScopeGpUnitIds) or (every $curId in tokenize(cdf:PartyScopeGpUnitIds) satisfies key('GpUnit',$curId))">PartyScopeGpUnitIds (<sch:value-of select="cdf:PartyScopeGpUnitIds"/> must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:LeaderPersonIds) or (every $curId in tokenize(cdf:LeaderPersonIds) satisfies key('Person',$curId))">LeaderPersonIds (<sch:value-of select="cdf:LeaderPersonIds"/> must point to an element of type Person</sch:assert>
+        </sch:rule>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit)">
+            <sch:assert test="not(cdf:ComposingGpUnitIds) or (every $curId in tokenize(cdf:ComposingGpUnitIds) satisfies key('GpUnit',$curId))">ComposingGpUnitIds (<sch:value-of select="cdf:ComposingGpUnitIds"/> must point to an element of type GpUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:Physical)">
-            <sch:assert test="not(err:BallotFormatId) or count(/cdf:BallotDefinition/cdf:BallotFormat[@ObjectId = current()/err:BallotFormatId]) = 1">) BallotFormatId (<sch:value-of select="cdf:BallotFormatId"/>) must point to an element of type BallotFormat</sch:assert>
+            <sch:assert test="not(cdf:BallotFormatId) or key('BallotFormat',current()/cdf:BallotFormatId)">) BallotFormatId (<sch:value-of select="cdf:BallotFormatId"/> must point to an element of type BallotFormat</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election)">
-            <sch:assert test="not(err:ElectionScopeId) or count(/cdf:BallotDefinition/cdf:GpUnit[@ObjectId = current()/err:ElectionScopeId]) = 1">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/> must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:OfficeGroup|/cdf:BallotDefinition/cdf:OfficeGroup/cdf:SubOfficeGroup|/cdf:BallotDefinition/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup)">
-            <sch:assert test="not(err:OfficeIds) or (every $curId in tokenize(err:OfficeIds) satisfies /cdf:BallotDefinition/cdf:Office[@ObjectId = $curId])">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
+            <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/> must point to an element of type Office</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle)">
-            <sch:assert test="not(err:PartyIds) or (every $curId in tokenize(err:PartyIds) satisfies /cdf:BallotDefinition/cdf:Party[@ObjectId = $curId])">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>            
-        </sch:rule>
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/> must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:GpUnitIds) or (every $curId in tokenize(cdf:GpUnitIds) satisfies key('GpUnit',$curId))">GpUnitIds (<sch:value-of select="cdf:GpUnitIds"/> must point to an element of type GpUnit</sch:assert>
+        </sch:rule>        
     </sch:pattern>
-    <sch:pattern>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit[contains(@xsi:type,'ReportingUnit')])">
-            <sch:assert test="not(err:Id) or count([@ObjectId = current()/err:Id]) = 1">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type Contest</sch:assert>
-            <sch:assert test="not(err:AuthorityIds) or (every $curId in tokenize(err:AuthorityIds) satisfies /cdf:BallotDefinition/cdf:Person[@ObjectId = $curId])">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/>) must point to an element of type Person</sch:assert>
+    <sch:pattern>        
+        <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit[@xsi:type = 'cdf:ReportingUnit'][contains(@xsi:type,'ReportingUnit')])">
+            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/> must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:AuthorityIds) or (every $curId in tokenize(cdf:AuthorityIds) satisfies key('Person',$curId))">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/> must point to an element of type Person</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')])">
-            <sch:assert test="not(err:ContestId) or count([@ObjectId = current()/err:ContestId]) = 1">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>            
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest'][contains(@xsi:type,'OrderedContest')])">
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/> must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:OrderedContestOptionIds) or (every $curId in tokenize(cdf:OrderedContestOptionIds) satisfies key('ContestOption',$curId))">OrderedContestOptionIds (<sch:value-of select="cdf:OrderedContestOptionIds"/> must point to an element of type ContestOption</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[contains(@xsi:type,'CandidateContest')])">
-            <sch:assert test="not(err:OfficeIds) or (every $curId in tokenize(err:OfficeIds) satisfies /cdf:BallotDefinition/cdf:Office[@ObjectId = $curId])">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
-            <sch:assert test="not(err:PrimaryPartyIds) or (every $curId in tokenize(err:PrimaryPartyIds) satisfies /cdf:BallotDefinition/cdf:Party[@ObjectId = $curId])">PrimaryPartyIds (<sch:value-of select="cdf:PrimaryPartyIds"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:CandidateContest'][contains(@xsi:type,'CandidateContest')])">
+            <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/> must point to an element of type Office</sch:assert>
+            <sch:assert test="not(cdf:PrimaryPartyIds) or (every $curId in tokenize(cdf:PrimaryPartyIds) satisfies key('Party',$curId))">PrimaryPartyIds (<sch:value-of select="cdf:PrimaryPartyIds"/> must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(err:CandidateId) or count(/cdf:BallotDefinition/cdf:Election/cdf:Candidate[@ObjectId = current()/err:CandidateId]) = 1">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
-            <sch:assert test="not(err:OfficeId) or count(/cdf:BallotDefinition/cdf:Office[@ObjectId = current()/err:OfficeId]) = 1">) OfficeId (<sch:value-of select="cdf:OfficeId"/>) must point to an element of type Office</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:RetentionContest'][contains(@xsi:type,'RetentionContest')])">
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)">) OfficeId (<sch:value-of select="cdf:OfficeId"/> must point to an element of type Office</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[contains(@xsi:type,'PartyOption')])">
-            <sch:assert test="not(err:PartyIds) or (every $curId in tokenize(err:PartyIds) satisfies /cdf:BallotDefinition/cdf:Party[@ObjectId = $curId])">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[@xsi:type = 'cdf:PartyOption'][contains(@xsi:type,'PartyOption')])">
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/> must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')])">
-            <sch:assert test="not(err:HeaderId) or count(/cdf:BallotDefinition/cdf:Header[@ObjectId = current()/err:HeaderId]) = 1">) HeaderId (<sch:value-of select="cdf:HeaderId"/>) must point to an element of type Header</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader'][contains(@xsi:type,'OrderedHeader')])">
+            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)">) HeaderId (<sch:value-of select="cdf:HeaderId"/> must point to an element of type Header</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[contains(@xsi:type,'ActivationContest')])">
-            <sch:assert test="not(err:CandidateId) or count(/cdf:BallotDefinition/cdf:Election/cdf:Candidate[@ObjectId = current()/err:CandidateId]) = 1">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:ActivationContest'][contains(@xsi:type,'ActivationContest')])">
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:BallotFormat/cdf:FiducialMark|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:FiducialMark[contains(@xsi:type,'FiducialMark')])">
-            <sch:assert test="not(err:ShapeId) or count(/cdf:BallotDefinition/cdf:Shape[@ObjectId = current()/err:ShapeId]) = 1">) ShapeId (<sch:value-of select="cdf:ShapeId"/>) must point to an element of type Shape</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[contains(@xsi:type,'ControllingContest')])">
+            <sch:assert test="not(cdf:ControlledContestIds) or (every $curId in tokenize(cdf:ControlledContestIds) satisfies key('Contest',$curId))">ControlledContestIds (<sch:value-of select="cdf:ControlledContestIds"/> must point to an element of type Contest</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:PhysicalContestOption/cdf:OptionPosition[contains(@xsi:type,'OptionPosition')])">
-            <sch:assert test="not(err:IndicatorId) or count(/cdf:BallotDefinition/cdf:Shape[@ObjectId = current()/err:IndicatorId]) = 1">) IndicatorId (<sch:value-of select="cdf:IndicatorId"/>) must point to an element of type Shape</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:BallotFormat/cdf:FiducialMark[@xsi:type = 'cdf:FiducialMark']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:FiducialMark[@xsi:type = 'cdf:FiducialMark'][contains(@xsi:type,'FiducialMark')])">
+            <sch:assert test="not(cdf:ShapeId) or key('Shape',current()/cdf:ShapeId)">) ShapeId (<sch:value-of select="cdf:ShapeId"/> must point to an element of type Shape</sch:assert>
         </sch:rule>
-        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[contains(@xsi:type,'CandidateOption')])">
-            <sch:assert test="not(err:CandidateIds) or (every $curId in tokenize(err:CandidateIds) satisfies /cdf:BallotDefinition/cdf:Election/cdf:Candidate[@ObjectId = $curId])">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
-            <sch:assert test="not(err:EndorsementPartyIds) or (every $curId in tokenize(err:EndorsementPartyIds) satisfies /cdf:BallotDefinition/cdf:Party[@ObjectId = $curId])">EndorsementPartyIds (<sch:value-of select="cdf:EndorsementPartyIds"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:PhysicalContestOption/cdf:OptionPosition[@xsi:type = 'cdf:OptionPosition'][contains(@xsi:type,'OptionPosition')])">
+            <sch:assert test="not(cdf:IndicatorId) or key('Shape',current()/cdf:IndicatorId)">) IndicatorId (<sch:value-of select="cdf:IndicatorId"/> must point to an element of type Shape</sch:assert>
+        </sch:rule>
+        <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[@xsi:type = 'cdf:CandidateOption'][contains(@xsi:type,'CandidateOption')])">
+            <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/> must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:EndorsementPartyIds) or (every $curId in tokenize(cdf:EndorsementPartyIds) satisfies key('Party',$curId))">EndorsementPartyIds (<sch:value-of select="cdf:EndorsementPartyIds"/> must point to an element of type Party</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/resources/bd_v1/bd_v1_sua.sch
+++ b/resources/bd_v1/bd_v1_sua.sch
@@ -16,24 +16,24 @@
     <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>
     <sch:pattern>        
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:PhysicalContestOption)">
-            <sch:assert test="not(cdf:ContestOptionId) or key('ContestOption',current()/cdf:ContestOptionId)">) ContestOptionId (<sch:value-of select="cdf:ContestOptionId"/> must point to an element of type ContestOption</sch:assert>
+            <sch:assert test="not(cdf:ContestOptionId) or key('ContestOption',current()/cdf:ContestOptionId)"> ContestOptionId (<sch:value-of select="cdf:ContestOptionId"/> must point to an element of type ContestOption</sch:assert>
         </sch:rule>        
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Candidate)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
-            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)">) PersonId (<sch:value-of select="cdf:PersonId"/> must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)"> PersonId (<sch:value-of select="cdf:PersonId"/> must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Person)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Office)">
             <sch:assert test="not(cdf:OfficeHolderPersonIds) or (every $curId in tokenize(cdf:OfficeHolderPersonIds) satisfies key('Person',$curId))">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/> must point to an element of type Person</sch:assert>
-            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)">) ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/> must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)"> ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/> must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit/cdf:ElectionAdministration)">
             <sch:assert test="not(cdf:ElectionOfficialPersonIds) or (every $curId in tokenize(cdf:ElectionOfficialPersonIds) satisfies key('Person',$curId))">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/> must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit/cdf:PartyRegistration)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/> must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Party)">
             <sch:assert test="not(cdf:PartyScopeGpUnitIds) or (every $curId in tokenize(cdf:PartyScopeGpUnitIds) satisfies key('GpUnit',$curId))">PartyScopeGpUnitIds (<sch:value-of select="cdf:PartyScopeGpUnitIds"/> must point to an element of type GpUnit</sch:assert>
@@ -43,10 +43,10 @@
             <sch:assert test="not(cdf:ComposingGpUnitIds) or (every $curId in tokenize(cdf:ComposingGpUnitIds) satisfies key('GpUnit',$curId))">ComposingGpUnitIds (<sch:value-of select="cdf:ComposingGpUnitIds"/> must point to an element of type GpUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:Physical)">
-            <sch:assert test="not(cdf:BallotFormatId) or key('BallotFormat',current()/cdf:BallotFormatId)">) BallotFormatId (<sch:value-of select="cdf:BallotFormatId"/> must point to an element of type BallotFormat</sch:assert>
+            <sch:assert test="not(cdf:BallotFormatId) or key('BallotFormat',current()/cdf:BallotFormatId)"> BallotFormatId (<sch:value-of select="cdf:BallotFormatId"/> must point to an element of type BallotFormat</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election)">
-            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/> must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)"> ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/> must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:OfficeGroup|/cdf:BallotDefinition/cdf:OfficeGroup/cdf:SubOfficeGroup|/cdf:BallotDefinition/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup)">
             <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/> must point to an element of type Office</sch:assert>
@@ -58,11 +58,11 @@
     </sch:pattern>
     <sch:pattern>        
         <sch:rule context="(/cdf:BallotDefinition/cdf:GpUnit[@xsi:type = 'cdf:ReportingUnit'][contains(@xsi:type,'ReportingUnit')])">
-            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/> must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)"> Id (<sch:value-of select="cdf:Id"/> must point to an element of type Contest</sch:assert>
             <sch:assert test="not(cdf:AuthorityIds) or (every $curId in tokenize(cdf:AuthorityIds) satisfies key('Person',$curId))">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/> must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedContest'][contains(@xsi:type,'OrderedContest')])">
-            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/> must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)"> ContestId (<sch:value-of select="cdf:ContestId"/> must point to an element of type Contest</sch:assert>
             <sch:assert test="not(cdf:OrderedContestOptionIds) or (every $curId in tokenize(cdf:OrderedContestOptionIds) satisfies key('ContestOption',$curId))">OrderedContestOptionIds (<sch:value-of select="cdf:OrderedContestOptionIds"/> must point to an element of type ContestOption</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:CandidateContest'][contains(@xsi:type,'CandidateContest')])">
@@ -70,26 +70,26 @@
             <sch:assert test="not(cdf:PrimaryPartyIds) or (every $curId in tokenize(cdf:PrimaryPartyIds) satisfies key('Party',$curId))">PrimaryPartyIds (<sch:value-of select="cdf:PrimaryPartyIds"/> must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:RetentionContest'][contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
-            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)">) OfficeId (<sch:value-of select="cdf:OfficeId"/> must point to an element of type Office</sch:assert>
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)"> CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)"> OfficeId (<sch:value-of select="cdf:OfficeId"/> must point to an element of type Office</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[@xsi:type = 'cdf:PartyOption'][contains(@xsi:type,'PartyOption')])">
             <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/> must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[@xsi:type = 'cdf:OrderedHeader'][contains(@xsi:type,'OrderedHeader')])">
-            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)">) HeaderId (<sch:value-of select="cdf:HeaderId"/> must point to an element of type Header</sch:assert>
+            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)"> HeaderId (<sch:value-of select="cdf:HeaderId"/> must point to an element of type Header</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[@xsi:type = 'cdf:ActivationContest'][contains(@xsi:type,'ActivationContest')])">
-            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)"> CandidateId (<sch:value-of select="cdf:CandidateId"/> must point to an element of type Candidate</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest[contains(@xsi:type,'ControllingContest')])">
             <sch:assert test="not(cdf:ControlledContestIds) or (every $curId in tokenize(cdf:ControlledContestIds) satisfies key('Contest',$curId))">ControlledContestIds (<sch:value-of select="cdf:ControlledContestIds"/> must point to an element of type Contest</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:BallotFormat/cdf:FiducialMark[@xsi:type = 'cdf:FiducialMark']|/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:FiducialMark[@xsi:type = 'cdf:FiducialMark'][contains(@xsi:type,'FiducialMark')])">
-            <sch:assert test="not(cdf:ShapeId) or key('Shape',current()/cdf:ShapeId)">) ShapeId (<sch:value-of select="cdf:ShapeId"/> must point to an element of type Shape</sch:assert>
+            <sch:assert test="not(cdf:ShapeId) or key('Shape',current()/cdf:ShapeId)"> ShapeId (<sch:value-of select="cdf:ShapeId"/> must point to an element of type Shape</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:Physical/cdf:PhysicalContestOption/cdf:OptionPosition[@xsi:type = 'cdf:OptionPosition'][contains(@xsi:type,'OptionPosition')])">
-            <sch:assert test="not(cdf:IndicatorId) or key('Shape',current()/cdf:IndicatorId)">) IndicatorId (<sch:value-of select="cdf:IndicatorId"/> must point to an element of type Shape</sch:assert>
+            <sch:assert test="not(cdf:IndicatorId) or key('Shape',current()/cdf:IndicatorId)"> IndicatorId (<sch:value-of select="cdf:IndicatorId"/> must point to an element of type Shape</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:BallotDefinition/cdf:Election/cdf:Contest/cdf:ContestOption[@xsi:type = 'cdf:CandidateOption'][contains(@xsi:type,'CandidateOption')])">
             <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/> must point to an element of type Candidate</sch:assert>

--- a/resources/cvr_v1/cvr_v1_sua.sch
+++ b/resources/cvr_v1/cvr_v1_sua.sch
@@ -23,32 +23,32 @@
     <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>            
     <sch:pattern>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest)">
-            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)"> ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:GpUnit|/cdf:CastVoteRecordReport/cdf:ReportingDevice)">
             <sch:assert test="not(cdf:ReportingDeviceIds) or (every $curId in tokenize(cdf:ReportingDeviceIds) satisfies key('ReportingDevice',$curId))">ReportingDeviceIds (<sch:value-of select="cdf:ReportingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election)">
-            <sch:assert test="not(cdf:ElectionScopeId) or key('GpUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionScopeId) or key('GpUnit',current()/cdf:ElectionScopeId)"> ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:Code|/cdf:CastVoteRecordReport/cdf:GpUnit/cdf:Code|/cdf:CastVoteRecordReport/cdf:Party/cdf:Code|/cdf:CastVoteRecordReport/cdf:ReportingDevice/cdf:Code)">
-            <sch:assert test="not(cdf:Id) or key('SelectionPosition',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type SelectionPosition</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('SelectionPosition',current()/cdf:Id)"> Id (<sch:value-of select="cdf:Id"/>) must point to an element of type SelectionPosition</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport)">
             <sch:assert test="not(cdf:ReportGeneratingDeviceIds) or (every $curId in tokenize(cdf:ReportGeneratingDeviceIds) satisfies key('ReportingDevice',$curId))">ReportGeneratingDeviceIds (<sch:value-of select="cdf:ReportGeneratingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest/cdf:CVRContestSelection)">
-            <sch:assert test="not(cdf:ContestSelectionId) or key('ContestSelection',current()/cdf:ContestSelectionId)">) ContestSelectionId (<sch:value-of select="cdf:ContestSelectionId"/>) must point to an element of type ContestSelection</sch:assert>
+            <sch:assert test="not(cdf:ContestSelectionId) or key('ContestSelection',current()/cdf:ContestSelectionId)"> ContestSelectionId (<sch:value-of select="cdf:ContestSelectionId"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR)">
-            <sch:assert test="not(cdf:CreatingDeviceId) or key('ReportingDevice',current()/cdf:CreatingDeviceId)">) CreatingDeviceId (<sch:value-of select="cdf:CreatingDeviceId"/>) must point to an element of type ReportingDevice</sch:assert>
-            <sch:assert test="not(cdf:ElectionId) or key('Election',current()/cdf:ElectionId)">) ElectionId (<sch:value-of select="cdf:ElectionId"/>) must point to an element of type Election</sch:assert>
-            <sch:assert test="not(cdf:CurrentSnapshotId) or key('CVRSnapshot',current()/cdf:CurrentSnapshotId)">) CurrentSnapshotId (<sch:value-of select="cdf:CurrentSnapshotId"/>) must point to an element of type CVRSnapshot</sch:assert>
+            <sch:assert test="not(cdf:CreatingDeviceId) or key('ReportingDevice',current()/cdf:CreatingDeviceId)"> CreatingDeviceId (<sch:value-of select="cdf:CreatingDeviceId"/>) must point to an element of type ReportingDevice</sch:assert>
+            <sch:assert test="not(cdf:ElectionId) or key('Election',current()/cdf:ElectionId)"> ElectionId (<sch:value-of select="cdf:ElectionId"/>) must point to an element of type Election</sch:assert>
+            <sch:assert test="not(cdf:CurrentSnapshotId) or key('CVRSnapshot',current()/cdf:CurrentSnapshotId)"> CurrentSnapshotId (<sch:value-of select="cdf:CurrentSnapshotId"/>) must point to an element of type CVRSnapshot</sch:assert>
             <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(cdf:BallotStyleUnitId) or key('GpUnit',current()/cdf:BallotStyleUnitId)">) BallotStyleUnitId (<sch:value-of select="cdf:BallotStyleUnitId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:BallotStyleUnitId) or key('GpUnit',current()/cdf:BallotStyleUnitId)"> BallotStyleUnitId (<sch:value-of select="cdf:BallotStyleUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
@@ -56,13 +56,13 @@
             <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest[contains(@xsi:type,'CandidateContest')])">
-            <sch:assert test="not(cdf:PrimaryPartyId) or key('Party',current()/cdf:PrimaryPartyId)">) PrimaryPartyId (<sch:value-of select="cdf:PrimaryPartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PrimaryPartyId) or key('Party',current()/cdf:PrimaryPartyId)"> PrimaryPartyId (<sch:value-of select="cdf:PrimaryPartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'PartySelection')])">
             <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest[contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)"> CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/resources/cvr_v1/cvr_v1_sua.sch
+++ b/resources/cvr_v1/cvr_v1_sua.sch
@@ -1,69 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?><sch:schema xmlns:mp="http://mapping" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">    
+    <xsl:key name="Contest" match="/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest"
+        use="@ObjectId"/>
+    <xsl:key name="ReportingDevice"
+        match="/cdf:CastVoteRecordReport/cdf:ReportingDevice"
+        use="@ObjectId"/>
+    <xsl:key name="Party" match="/cdf:CastVoteRecordReport/cdf:Party" use="@ObjectId"/>
+    <xsl:key name="GpUnit"
+        match="/cdf:CastVoteRecordReport/cdf:GpUnit | /cdf:CastVoteRecordReport/cdf:ReportingDevice"
+        use="@ObjectId"/>
+    <xsl:key name="SelectionPosition"
+        match="/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest/cdf:CVRContestSelection/cdf:SelectionPosition"
+        use="@ObjectId"/>
+    <xsl:key name="ContestSelection"
+        match="/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection"
+        use="@ObjectId"/>
+    <xsl:key name="Election" match="/cdf:CastVoteRecordReport/cdf:Election" use="@ObjectId"/>
+    <xsl:key name="CVRSnapshot" match="/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot"
+        use="@ObjectId"/>
+    <xsl:key name="Candidate" match="/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate"
+        use="@ObjectId"/>
     <sch:ns uri="http://itl.nist.gov/ns/voting/1500-103/v1" prefix="cdf"/>    
-    <sch:ns uri="http://itl.nist.gov/ns/voting/1500-103/v1" prefix="err"/>   
     <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>            
     <sch:pattern>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest)">
-            <sch:assert test="not(err:ContestId) or count([@ObjectId = current()/err:ContestId]) = 1">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
         </sch:rule>
-
-
-        <sch:rule context="(/cdf:CastVoteRecordReport/cdf:GpUnit)">
-            <sch:assert test="not(err:ReportingDeviceIds) or (every $curId in tokenize(err:ReportingDeviceIds) satisfies /cdf:CastVoteRecordReport/cdf:ReportingDevice[@ObjectId = $curId])">ReportingDeviceIds (<sch:value-of select="cdf:ReportingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
+        <sch:rule context="(/cdf:CastVoteRecordReport/cdf:GpUnit|/cdf:CastVoteRecordReport/cdf:ReportingDevice)">
+            <sch:assert test="not(cdf:ReportingDeviceIds) or (every $curId in tokenize(cdf:ReportingDeviceIds) satisfies key('ReportingDevice',$curId))">ReportingDeviceIds (<sch:value-of select="cdf:ReportingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
         </sch:rule>
-
-
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate)">
-            <sch:assert test="not(err:PartyId) or count(/cdf:CastVoteRecordReport/cdf:Party[@ObjectId = current()/err:PartyId]) = 1">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-
-
-
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election)">
-            <sch:assert test="not(err:ElectionScopeId) or count(/cdf:CastVoteRecordReport/cdf:GpUnit[@ObjectId = current()/err:ElectionScopeId]) = 1">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionScopeId) or key('GpUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
-
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:Code|/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:Code|/cdf:CastVoteRecordReport/cdf:GpUnit/cdf:Code|/cdf:CastVoteRecordReport/cdf:Party/cdf:Code|/cdf:CastVoteRecordReport/cdf:ReportingDevice/cdf:Code)">
-            <sch:assert test="not(err:Id) or count(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest/cdf:CVRContestSelection/cdf:SelectionPosition[@ObjectId = current()/err:Id]) = 1">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type SelectionPosition</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('SelectionPosition',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type SelectionPosition</sch:assert>
         </sch:rule>
-
-
         <sch:rule context="(/cdf:CastVoteRecordReport)">
-            <sch:assert test="not(err:ReportGeneratingDeviceIds) or (every $curId in tokenize(err:ReportGeneratingDeviceIds) satisfies /cdf:CastVoteRecordReport/cdf:ReportingDevice[@ObjectId = $curId])">ReportGeneratingDeviceIds (<sch:value-of select="cdf:ReportGeneratingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
+            <sch:assert test="not(cdf:ReportGeneratingDeviceIds) or (every $curId in tokenize(cdf:ReportGeneratingDeviceIds) satisfies key('ReportingDevice',$curId))">ReportGeneratingDeviceIds (<sch:value-of select="cdf:ReportGeneratingDeviceIds"/>) must point to an element of type ReportingDevice</sch:assert>
         </sch:rule>
-
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot/cdf:CVRContest/cdf:CVRContestSelection)">
-            <sch:assert test="not(err:ContestSelectionId) or count(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection[@ObjectId = current()/err:ContestSelectionId]) = 1">) ContestSelectionId (<sch:value-of select="cdf:ContestSelectionId"/>) must point to an element of type ContestSelection</sch:assert>
+            <sch:assert test="not(cdf:ContestSelectionId) or key('ContestSelection',current()/cdf:ContestSelectionId)">) ContestSelectionId (<sch:value-of select="cdf:ContestSelectionId"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
-
-
-
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:CVR)">
-            <sch:assert test="not(err:CreatingDeviceId) or count(/cdf:CastVoteRecordReport/cdf:ReportingDevice[@ObjectId = current()/err:CreatingDeviceId]) = 1">) CreatingDeviceId (<sch:value-of select="cdf:CreatingDeviceId"/>) must point to an element of type ReportingDevice</sch:assert>
-            <sch:assert test="not(err:ElectionId) or count(/cdf:CastVoteRecordReport/cdf:Election[@ObjectId = current()/err:ElectionId]) = 1">) ElectionId (<sch:value-of select="cdf:ElectionId"/>) must point to an element of type Election</sch:assert>
-            <sch:assert test="not(err:CurrentSnapshotId) or count(/cdf:CastVoteRecordReport/cdf:CVR/cdf:CVRSnapshot[@ObjectId = current()/err:CurrentSnapshotId]) = 1">) CurrentSnapshotId (<sch:value-of select="cdf:CurrentSnapshotId"/>) must point to an element of type CVRSnapshot</sch:assert>
-            <sch:assert test="not(err:PartyIds) or (every $curId in tokenize(err:PartyIds) satisfies /cdf:CastVoteRecordReport/cdf:Party[@ObjectId = $curId])">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(err:BallotStyleUnitId) or count(/cdf:CastVoteRecordReport/cdf:GpUnit[@ObjectId = current()/err:BallotStyleUnitId]) = 1">) BallotStyleUnitId (<sch:value-of select="cdf:BallotStyleUnitId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:CreatingDeviceId) or key('ReportingDevice',current()/cdf:CreatingDeviceId)">) CreatingDeviceId (<sch:value-of select="cdf:CreatingDeviceId"/>) must point to an element of type ReportingDevice</sch:assert>
+            <sch:assert test="not(cdf:ElectionId) or key('Election',current()/cdf:ElectionId)">) ElectionId (<sch:value-of select="cdf:ElectionId"/>) must point to an element of type Election</sch:assert>
+            <sch:assert test="not(cdf:CurrentSnapshotId) or key('CVRSnapshot',current()/cdf:CurrentSnapshotId)">) CurrentSnapshotId (<sch:value-of select="cdf:CurrentSnapshotId"/>) must point to an element of type CVRSnapshot</sch:assert>
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:BallotStyleUnitId) or key('GpUnit',current()/cdf:BallotStyleUnitId)">) BallotStyleUnitId (<sch:value-of select="cdf:BallotStyleUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
-
     </sch:pattern>
     <sch:pattern>
-
-        
-
-
-
+        <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'CandidateSelection')])">
+            <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
+        </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest[contains(@xsi:type,'CandidateContest')])">
-            <sch:assert test="not(err:PrimaryPartyId) or count(/cdf:CastVoteRecordReport/cdf:Party[@ObjectId = current()/err:PrimaryPartyId]) = 1">) PrimaryPartyId (<sch:value-of select="cdf:PrimaryPartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PrimaryPartyId) or key('Party',current()/cdf:PrimaryPartyId)">) PrimaryPartyId (<sch:value-of select="cdf:PrimaryPartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-
-        
-
+        <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'PartySelection')])">
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+        </sch:rule>
         <sch:rule context="(/cdf:CastVoteRecordReport/cdf:Election/cdf:Contest[contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(err:CandidateId) or count(/cdf:CastVoteRecordReport/cdf:Election/cdf:Candidate[@ObjectId = current()/err:CandidateId]) = 1">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
         </sch:rule>
-
-
-
     </sch:pattern>
 </sch:schema>

--- a/resources/eel_v1/json2xml.xsl
+++ b/resources/eel_v1/json2xml.xsl
@@ -4,9 +4,7 @@
 	<!-- the root node must be XML, meaning the JSON must be nested in XML (not ideal) -->
 	<xsl:template name="start" match=".[. instance of map(*)]" priority="1">
 		<xsl:variable name="xml">
-			<ElectionEventLog>
-				<xsl:apply-templates select=". => serialize(map { 'method' : 'json' }) => json-to-xml()"/>
-			</ElectionEventLog>
+			<xsl:apply-templates select=". => serialize(map { 'method' : 'json' }) => json-to-xml()"/>
 		</xsl:variable>
 		<xsl:copy-of select="$xml"/>
 	</xsl:template>

--- a/resources/eel_v1/json2xml.xsl
+++ b/resources/eel_v1/json2xml.xsl
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xml:id="json2xml" xpath-default-namespace="http://www.w3.org/2005/xpath-functions" xmlns="http://itl.nist.gov/ns/voting/1500-101/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdf="afssaf" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:array="http://www.w3.org/2005/xpath-functions/array" xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:err="http://www.w3.org/2005/xqt-errors" exclude-result-prefixes="array cdf fn map math xhtml err xs" version="3.0">
+<xsl:stylesheet xml:id="json2xml" xpath-default-namespace="http://www.w3.org/2005/xpath-functions" xmlns="http://itl.nist.gov/ns/voting/1500-101/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdf="http://itl.nist.gov/ns/voting/1500-101/v1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:array="http://www.w3.org/2005/xpath-functions/array" xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:err="http://www.w3.org/2005/xqt-errors" exclude-result-prefixes="array cdf fn map math xhtml err xs" version="3.0">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!-- the root node must be XML, meaning the JSON must be nested in XML (not ideal) -->
 	<xsl:template name="start" match=".[. instance of map(*)]" priority="1">
 		<xsl:variable name="xml">
-			<xsl:apply-templates select=". => serialize(map { 'method' : 'json' }) => json-to-xml()"/>
+			<ElectionEventLog>
+				<xsl:apply-templates select=". => serialize(map { 'method' : 'json' }) => json-to-xml()"/>
+			</ElectionEventLog>
 		</xsl:variable>
 		<xsl:copy-of select="$xml"/>
 	</xsl:template>
@@ -27,6 +29,11 @@
 				<xsl:value-of select="*[@key = 'HashType']"/>
 			</HashType>
 		</xsl:if>
+		<xsl:if test="boolean(*[@key = 'OtherHashType'])">
+			<OtherHashType>
+				<xsl:value-of select="*[@key = 'OtherHashType']"/>
+			</OtherHashType>
+		</xsl:if>
 		<xsl:if test="boolean(*[@key = 'Id'])">
 			<Id>
 				<xsl:value-of select="*[@key = 'Id']"/>
@@ -41,11 +48,6 @@
 			<Model>
 				<xsl:value-of select="*[@key = 'Model']"/>
 			</Model>
-		</xsl:if>
-		<xsl:if test="boolean(*[@key = 'OtherHashType'])">
-			<OtherHashType>
-				<xsl:value-of select="*[@key = 'OtherHashType']"/>
-			</OtherHashType>
 		</xsl:if>
 		<xsl:if test="boolean(*[@key = 'Type'])">
 			<Type>
@@ -65,7 +67,7 @@
 	</xsl:template>
 	<xsl:template name="cdf:ElectionEventLog" match="*[string = 'EventLogging.ElectionEventLog' and string/@key = '@type']">
 		<xsl:param name="set_type" select="true()"/>
-		<ElectionEventLog>
+		<ElectionEventLog>		
 			<xsl:if test="boolean(*[@key = 'Details'])">
 				<Details>
 					<xsl:value-of select="*[@key = 'Details']"/>

--- a/resources/err_v2/err_v2_sua.sch
+++ b/resources/err_v2/err_v2_sua.sch
@@ -15,24 +15,24 @@
     <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>            
     <sch:pattern>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Candidate)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)">) PersonId (<sch:value-of select="cdf:PersonId"/>) must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)"> PersonId (<sch:value-of select="cdf:PersonId"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Person)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Office)">
-            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)">) ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/>) must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)"> ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/>) must point to an element of type ReportingUnit</sch:assert>
             <sch:assert test="not(cdf:OfficeHolderPersonIds) or (every $curId in tokenize(cdf:OfficeHolderPersonIds) satisfies key('Person',$curId))">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotCounts|/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:VoteCounts)">
-            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)">) GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)"> GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit/cdf:ElectionAdministration)">
             <sch:assert test="not(cdf:ElectionOfficialPersonIds) or (every $curId in tokenize(cdf:ElectionOfficialPersonIds) satisfies key('Person',$curId))">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit/cdf:PartyRegistration)">
-            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Party)">
             <sch:assert test="not(cdf:LeaderPersonIds) or (every $curId in tokenize(cdf:LeaderPersonIds) satisfies key('Person',$curId))">LeaderPersonIds (<sch:value-of select="cdf:LeaderPersonIds"/>) must point to an element of type Person</sch:assert>
@@ -42,7 +42,7 @@
             <sch:assert test="not(cdf:ComposingGpUnitIds) or (every $curId in tokenize(cdf:ComposingGpUnitIds) satisfies key('GpUnit',$curId))">ComposingGpUnitIds (<sch:value-of select="cdf:ComposingGpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election)">
-            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)"> ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:OfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup)">
             <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
@@ -52,20 +52,20 @@
             <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:OtherCounts)">
-            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)">) GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)"> GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
         <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit[contains(@xsi:type,'ReportingUnit')])">
             <sch:assert test="not(cdf:AuthorityIds) or (every $curId in tokenize(cdf:AuthorityIds) satisfies key('Person',$curId))">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/>) must point to an element of type Person</sch:assert>
-            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)"> Id (<sch:value-of select="cdf:Id"/>) must point to an element of type Contest</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'CandidateSelection')])">
             <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
             <sch:assert test="not(cdf:EndorsementPartyIds) or (every $curId in tokenize(cdf:EndorsementPartyIds) satisfies key('Party',$curId))">EndorsementPartyIds (<sch:value-of select="cdf:EndorsementPartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')])">
-            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)"> ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
             <sch:assert test="not(cdf:OrderedContestSelectionIds) or (every $curId in tokenize(cdf:OrderedContestSelectionIds) satisfies key('ContestSelection',$curId))">OrderedContestSelectionIds (<sch:value-of select="cdf:OrderedContestSelectionIds"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest[contains(@xsi:type,'CandidateContest')])">
@@ -76,14 +76,14 @@
             <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest[contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
-            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)">) OfficeId (<sch:value-of select="cdf:OfficeId"/>) must point to an element of type Office</sch:assert>
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)"> CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)"> OfficeId (<sch:value-of select="cdf:OfficeId"/>) must point to an element of type Office</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:VoteCounts[contains(@xsi:type,'VoteCounts')])">
-            <sch:assert test="not(cdf:Id) or key('ContestSelection',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type ContestSelection</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('ContestSelection',current()/cdf:Id)"> Id (<sch:value-of select="cdf:Id"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
         <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')])">
-            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)">) HeaderId (<sch:value-of select="cdf:HeaderId"/>) must point to an element of type Header</sch:assert>
+            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)"> HeaderId (<sch:value-of select="cdf:HeaderId"/>) must point to an element of type Header</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/resources/err_v2/err_v2_sua.sch
+++ b/resources/err_v2/err_v2_sua.sch
@@ -1,78 +1,89 @@
-<?xml version="1.0" encoding="UTF-8"?><sch:schema xmlns:mp="http://mapping" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">    
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:mp="http://mapping" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">    
+    <xsl:key name="Party" match="/cdf:ElectionReport/cdf:Party" use="@ObjectId"/>
+    <xsl:key name="Person" match="/cdf:ElectionReport/cdf:Person" use="@ObjectId"/>
+    <xsl:key name="ReportingUnit"
+        match="/cdf:ElectionReport/cdf:GpUnit[contains(@xsi:type, 'ReportingUnit')]" use="@ObjectId"/>
+    <xsl:key name="GpUnit" match="/cdf:ElectionReport/cdf:GpUnit" use="@ObjectId"/>
+    <xsl:key name="Office" match="/cdf:ElectionReport/cdf:Office" use="@ObjectId"/>
+    <xsl:key name="Contest" match="/cdf:ElectionReport/cdf:Election/cdf:Contest" use="@ObjectId"/>
+    <xsl:key name="Candidate" match="/cdf:ElectionReport/cdf:Election/cdf:Candidate" use="@ObjectId"/>
+    <xsl:key name="ContestSelection"
+        match="/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection" use="@ObjectId"/>
+    <xsl:key name="Header" match="/cdf:ElectionReport/cdf:Header" use="@ObjectId"/>
     <sch:ns uri="http://itl.nist.gov/ns/voting/1500-100/v2" prefix="cdf"/>    
-    <sch:ns uri="http://itl.nist.gov/ns/voting/1500-100/v2" prefix="err"/>
-    <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>
-    
-    <sch:pattern>        
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Candidate)">
-            <sch:assert test="not(err:PartyId) or count(/err:ElectionReport/err:Party[@ObjectId = current()/err:PartyId]) = 1"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(err:PersonId) or count(/err:ElectionReport/err:Person[@ObjectId = current()/err:PersonId]) = 1"> PersonId (<sch:value-of select="cdf:PersonId"/>) must point to an element of type Person</sch:assert>
+    <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>            
+    <sch:pattern>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Candidate)">
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+            <sch:assert test="not(cdf:PersonId) or key('Person',current()/cdf:PersonId)">) PersonId (<sch:value-of select="cdf:PersonId"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Person)">
-            <sch:assert test="not(err:PartyId) or count(/err:ElectionReport/err:Party[@ObjectId = current()/err:PartyId]) = 1"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Person)">
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Office)">
-            <sch:assert test="not(err:OfficeHolderPersonIds) or (every $curId in tokenize(err:OfficeHolderPersonIds) satisfies /err:ElectionReport/err:Person[@ObjectId = $curId])">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/>) must point to an element of type Person</sch:assert>
-            <sch:assert test="not(err:ElectionDistrictId) or count(/err:ElectionReport/err:GpUnit[@ObjectId = current()/err:ElectionDistrictId]) = 1"> ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/>) must point to an element of type ReportingUnit</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Office)">
+            <sch:assert test="not(cdf:ElectionDistrictId) or key('ReportingUnit',current()/cdf:ElectionDistrictId)">) ElectionDistrictId (<sch:value-of select="cdf:ElectionDistrictId"/>) must point to an element of type ReportingUnit</sch:assert>
+            <sch:assert test="not(cdf:OfficeHolderPersonIds) or (every $curId in tokenize(cdf:OfficeHolderPersonIds) satisfies key('Person',$curId))">OfficeHolderPersonIds (<sch:value-of select="cdf:OfficeHolderPersonIds"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
-        
-        <sch:rule context="(/err:ElectionReport/err:GpUnit/err:ElectionAdministration)">
-            <sch:assert test="not(err:ElectionOfficialPersonIds) or (every $curId in tokenize(err:ElectionOfficialPersonIds) satisfies /err:ElectionReport/err:Person[@ObjectId = $curId])">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/>) must point to an element of type Person</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotCounts|/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:VoteCounts)">
+            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)">) GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:GpUnit/err:PartyRegistration)">
-            <sch:assert test="not(err:PartyId) or count(/err:ElectionReport/err:Party[@ObjectId = current()/err:PartyId]) = 1"> PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit/cdf:ElectionAdministration)">
+            <sch:assert test="not(cdf:ElectionOfficialPersonIds) or (every $curId in tokenize(cdf:ElectionOfficialPersonIds) satisfies key('Person',$curId))">ElectionOfficialPersonIds (<sch:value-of select="cdf:ElectionOfficialPersonIds"/>) must point to an element of type Person</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Party)">
-            <sch:assert test="not(err:PartyScopeGpUnitIds) or (every $curId in tokenize(err:PartyScopeGpUnitIds) satisfies /err:ElectionReport/err:GpUnit[@ObjectId = $curId])">PartyScopeGpUnitIds (<sch:value-of select="cdf:PartyScopeGpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
-            <sch:assert test="not(err:LeaderPersonIds) or (every $curId in tokenize(err:LeaderPersonIds) satisfies /err:ElectionReport/err:Person[@ObjectId = $curId])">LeaderPersonIds (<sch:value-of select="cdf:LeaderPersonIds"/>) must point to an element of type Person</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit/cdf:PartyRegistration)">
+            <sch:assert test="not(cdf:PartyId) or key('Party',current()/cdf:PartyId)">) PartyId (<sch:value-of select="cdf:PartyId"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-        <!--<sch:rule context="(/err:ElectionReport/err:GpUnit)">
-            <sch:assert test="not(err:ComposingGpUnitIds) or (every $curId in tokenize(err:ComposingGpUnitIds) satisfies /err:ElectionReport/err:GpUnit[@ObjectId = $curId])">ComposingGpUnitIds (<sch:value-of select="cdf:ComposingGpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
-        </sch:rule>-->
-        <sch:rule context="(/err:ElectionReport/err:Election)">
-            <sch:assert test="not(err:ElectionScopeId) or count(/err:ElectionReport/err:GpUnit[@ObjectId = current()/err:ElectionScopeId]) = 1"> ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type ReportingUnit</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Party)">
+            <sch:assert test="not(cdf:LeaderPersonIds) or (every $curId in tokenize(cdf:LeaderPersonIds) satisfies key('Person',$curId))">LeaderPersonIds (<sch:value-of select="cdf:LeaderPersonIds"/>) must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:PartyScopeGpUnitIds) or (every $curId in tokenize(cdf:PartyScopeGpUnitIds) satisfies key('GpUnit',$curId))">PartyScopeGpUnitIds (<sch:value-of select="cdf:PartyScopeGpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:OfficeGroup|/err:ElectionReport/err:OfficeGroup/err:SubOfficeGroup|/err:ElectionReport/err:OfficeGroup/err:SubOfficeGroup/err:SubOfficeGroup)">
-            <sch:assert test="not(err:OfficeIds) or (every $curId in tokenize(err:OfficeIds) satisfies /err:ElectionReport/err:Office[@ObjectId = $curId])">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit)">
+            <sch:assert test="not(cdf:ComposingGpUnitIds) or (every $curId in tokenize(cdf:ComposingGpUnitIds) satisfies key('GpUnit',$curId))">ComposingGpUnitIds (<sch:value-of select="cdf:ComposingGpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest/err:OtherCounts)">
-            <sch:assert test="not(err:GpUnitId) or count(/err:ElectionReport/err:GpUnit[@ObjectId = current()/err:GpUnitId]) = 1"> GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election)">
+            <sch:assert test="not(cdf:ElectionScopeId) or key('ReportingUnit',current()/cdf:ElectionScopeId)">) ElectionScopeId (<sch:value-of select="cdf:ElectionScopeId"/>) must point to an element of type ReportingUnit</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:BallotStyle)">
-            <sch:assert test="not(err:GpUnitIds) or (every $curId in tokenize(err:GpUnitIds) satisfies /err:ElectionReport/err:GpUnit[@ObjectId = $curId])">GpUnitIds (<sch:value-of select="cdf:GpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
-            <sch:assert test="not(err:PartyIds) or (every $curId in tokenize(err:PartyIds) satisfies /err:ElectionReport/err:Party[@ObjectId = $curId])">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:OfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup|/cdf:ElectionReport/cdf:OfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup/cdf:SubOfficeGroup)">
+            <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
+        </sch:rule>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotStyle)">
+            <sch:assert test="not(cdf:GpUnitIds) or (every $curId in tokenize(cdf:GpUnitIds) satisfies key('GpUnit',$curId))">GpUnitIds (<sch:value-of select="cdf:GpUnitIds"/>) must point to an element of type GpUnit</sch:assert>
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+        </sch:rule>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:OtherCounts)">
+            <sch:assert test="not(cdf:GpUnitId) or key('GpUnit',current()/cdf:GpUnitId)">) GpUnitId (<sch:value-of select="cdf:GpUnitId"/>) must point to an element of type GpUnit</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="(/err:ElectionReport/err:GpUnit[contains(@xsi:type,'ReportingUnit')])">
-            <sch:assert test="not(err:Id) or count([@ObjectId = current()/err:Id]) = 1"> Id (<sch:value-of select="cdf:Id"/>) must point to an element of type Contest</sch:assert>
-            <sch:assert test="not(err:AuthorityIds) or (every $curId in tokenize(err:AuthorityIds) satisfies /err:ElectionReport/err:Person[@ObjectId = $curId])">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/>) must point to an element of type Person</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:GpUnit[contains(@xsi:type,'ReportingUnit')])">
+            <sch:assert test="not(cdf:AuthorityIds) or (every $curId in tokenize(cdf:AuthorityIds) satisfies key('Person',$curId))">AuthorityIds (<sch:value-of select="cdf:AuthorityIds"/>) must point to an element of type Person</sch:assert>
+            <sch:assert test="not(cdf:Id) or key('Contest',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type Contest</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest/err:ContestSelection[contains(@xsi:type,'CandidateSelection')])">
-            <sch:assert test="not(err:EndorsementPartyIds) or (every $curId in tokenize(err:EndorsementPartyIds) satisfies /err:ElectionReport/err:Party[@ObjectId = $curId])">EndorsementPartyIds (<sch:value-of select="cdf:EndorsementPartyIds"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(err:CandidateIds) or (every $curId in tokenize(err:CandidateIds) satisfies /err:ElectionReport/err:Election/err:Candidate[@ObjectId = $curId])">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'CandidateSelection')])">
+            <sch:assert test="not(cdf:CandidateIds) or (every $curId in tokenize(cdf:CandidateIds) satisfies key('Candidate',$curId))">CandidateIds (<sch:value-of select="cdf:CandidateIds"/>) must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:EndorsementPartyIds) or (every $curId in tokenize(cdf:EndorsementPartyIds) satisfies key('Party',$curId))">EndorsementPartyIds (<sch:value-of select="cdf:EndorsementPartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent/err:OrderedContent|/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent/err:OrderedContent/err:OrderedContent|/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent[contains(@xsi:type,'OrderedContest')])">
-            <sch:assert test="not(err:OrderedContestSelectionIds) or (every $curId in tokenize(err:OrderedContestSelectionIds) satisfies /err:ElectionReport/err:Election/err:Contest/err:ContestSelection[@ObjectId = $curId])">OrderedContestSelectionIds (<sch:value-of select="cdf:OrderedContestSelectionIds"/>) must point to an element of type ContestSelection</sch:assert>
-            <sch:assert test="not(err:ContestId) or count([@ObjectId = current()/err:ContestId]) = 1"> ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[contains(@xsi:type,'OrderedContest')])">
+            <sch:assert test="not(cdf:ContestId) or key('Contest',current()/cdf:ContestId)">) ContestId (<sch:value-of select="cdf:ContestId"/>) must point to an element of type Contest</sch:assert>
+            <sch:assert test="not(cdf:OrderedContestSelectionIds) or (every $curId in tokenize(cdf:OrderedContestSelectionIds) satisfies key('ContestSelection',$curId))">OrderedContestSelectionIds (<sch:value-of select="cdf:OrderedContestSelectionIds"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest[contains(@xsi:type,'CandidateContest')])">
-            <sch:assert test="not(err:PrimaryPartyIds) or (every $curId in tokenize(err:PrimaryPartyIds) satisfies /err:ElectionReport/err:Party[@ObjectId = $curId])">PrimaryPartyIds (<sch:value-of select="cdf:PrimaryPartyIds"/>) must point to an element of type Party</sch:assert>
-            <sch:assert test="not(err:OfficeIds) or (every $curId in tokenize(err:OfficeIds) satisfies /err:ElectionReport/err:Office[@ObjectId = $curId])">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest[contains(@xsi:type,'CandidateContest')])">
+            <sch:assert test="not(cdf:OfficeIds) or (every $curId in tokenize(cdf:OfficeIds) satisfies key('Office',$curId))">OfficeIds (<sch:value-of select="cdf:OfficeIds"/>) must point to an element of type Office</sch:assert>
+            <sch:assert test="not(cdf:PrimaryPartyIds) or (every $curId in tokenize(cdf:PrimaryPartyIds) satisfies key('Party',$curId))">PrimaryPartyIds (<sch:value-of select="cdf:PrimaryPartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-        
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest/err:ContestSelection[contains(@xsi:type,'PartySelection')])">
-            <sch:assert test="not(err:PartyIds) or (every $curId in tokenize(err:PartyIds) satisfies /err:ElectionReport/err:Party[@ObjectId = $curId])">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection[contains(@xsi:type,'PartySelection')])">
+            <sch:assert test="not(cdf:PartyIds) or (every $curId in tokenize(cdf:PartyIds) satisfies key('Party',$curId))">PartyIds (<sch:value-of select="cdf:PartyIds"/>) must point to an element of type Party</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest[contains(@xsi:type,'RetentionContest')])">
-            <sch:assert test="not(err:CandidateId) or count(/err:ElectionReport/err:Election/err:Candidate[@ObjectId = current()/err:CandidateId]) = 1"> CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
-            <sch:assert test="not(err:OfficeId) or count(/err:ElectionReport/err:Office[@ObjectId = current()/err:OfficeId]) = 1"> OfficeId (<sch:value-of select="cdf:OfficeId"/>) must point to an element of type Office</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest[contains(@xsi:type,'RetentionContest')])">
+            <sch:assert test="not(cdf:CandidateId) or key('Candidate',current()/cdf:CandidateId)">) CandidateId (<sch:value-of select="cdf:CandidateId"/>) must point to an element of type Candidate</sch:assert>
+            <sch:assert test="not(cdf:OfficeId) or key('Office',current()/cdf:OfficeId)">) OfficeId (<sch:value-of select="cdf:OfficeId"/>) must point to an element of type Office</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:Contest/err:ContestSelection/err:VoteCounts[contains(@xsi:type,'VoteCounts')])">
-            <sch:assert test="not(err:Id) or count(/err:ElectionReport/err:Election/err:Contest/err:ContestSelection[@ObjectId = current()/err:Id]) = 1"> Id (<sch:value-of select="cdf:Id"/>) must point to an element of type ContestSelection</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:Contest/cdf:ContestSelection/cdf:VoteCounts[contains(@xsi:type,'VoteCounts')])">
+            <sch:assert test="not(cdf:Id) or key('ContestSelection',current()/cdf:Id)">) Id (<sch:value-of select="cdf:Id"/>) must point to an element of type ContestSelection</sch:assert>
         </sch:rule>
-        <sch:rule context="(/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent|/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent/err:OrderedContent|/err:ElectionReport/err:Election/err:BallotStyle/err:OrderedContent/err:OrderedContent/err:OrderedContent[contains(@xsi:type,'OrderedHeader')])">
-            <sch:assert test="not(err:HeaderId) or count(/err:ElectionReport/err:Header[@ObjectId = current()/err:HeaderId]) = 1"> HeaderId (<sch:value-of select="cdf:HeaderId"/>) must point to an element of type Header</sch:assert>
+        <sch:rule context="(/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')]|/cdf:ElectionReport/cdf:Election/cdf:BallotStyle/cdf:OrderedContent/cdf:OrderedContent/cdf:OrderedContent[contains(@xsi:type,'OrderedHeader')])">
+            <sch:assert test="not(cdf:HeaderId) or key('Header',current()/cdf:HeaderId)">) HeaderId (<sch:value-of select="cdf:HeaderId"/>) must point to an element of type Header</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/testcdf.bat
+++ b/testcdf.bat
@@ -4,7 +4,7 @@ setlocal
 
 IF NOT "%2"=="-silent" (
 ECHO NIST Voting 🗳️  Program - Common Data Format Test Method
-ECHO Version 1.0.0beta3 using...
+ECHO Version 1.0.0beta4 using...
 )
 where java >nul 2>nul
 if %errorlevel%==1 (

--- a/testcdf.sh
+++ b/testcdf.sh
@@ -4,7 +4,7 @@ CURRENT_SCRIPT=$0
 if [ "$2" != "-silent" ]
 then
     echo NIST Voting 🗳️  Program - Common Data Format Test Method
-     echo Version 1.0.0beta3 using...
+     echo Version 1.0.0beta4 using...
 fi
 MORGANA_HOME=$(dirname $CURRENT_SCRIPT)
 MORGANA_LIB=$MORGANA_HOME/libraries/*


### PR DESCRIPTION
- Updates Schematron rulesets to use `xsl:key` which provides O(1) lookups for referenced ObjectIds.
- Fixes an issue with EEL json2xml conversion where tags were apprearing in the wrong order
- Fixes an issue where the input document uri would not appear in error messages