### PR TITLE
Integrate fixes to GEN-01 and add Massachusetts JSON files

### DIFF
--- a/pipelines/consolidate_reports.xpl
+++ b/pipelines/consolidate_reports.xpl
@@ -14,7 +14,7 @@
         <p:with-input port="insertion">
             <p:inline>
                 <xvrl:metadata xmlns:xvrl="http://www.xproc.org/ns/xvrl">
-                    <xvrl:creator name="NIST Common Data Format Test Method" version="1.0.0" />
+                    <xvrl:creator name="NIST Common Data Format Test Method" version="1.0.1" />
                     <xvrl:timestamp>{$start-dateTime}</xvrl:timestamp>
                     <xvrl:summary>Please review each report to determine conformance to the applicable test assertions / requirements</xvrl:summary>
                     <xvrl:supplemental tm:xproc-engine-name="{p:system-property('p:product-name')}"

--- a/test_data/real_world/ma/cambridge/2022/general/err_v2/err-2022-11-08-Massachusetts-Cambridge.json
+++ b/test_data/real_world/ma/cambridge/2022/general/err_v2/err-2022-11-08-Massachusetts-Cambridge.json
@@ -1,0 +1,17503 @@
+
+ { "Election" : 
+  [ 
+   { "BallotCounts" : 
+    [ 
+     { "BallotsCast" : 628,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 302,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 27,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1090,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1158,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1087,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 944,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 97,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 842,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1126,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 727,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 417,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1436,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1136,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 187,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1284,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1190,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 164,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1171,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1094,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 348,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 758,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1510,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1316,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 895,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 34,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 338,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1182,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1209,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 303,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1994,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1487,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1479,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1051,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 669,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1733,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1225,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 436,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 521,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 821,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1337,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 144,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3A",
+      "Type" : "total" } ],
+    "BallotStyle" : 
+    [ 
+     { "GpUnitIds" : 
+      [ "prec-1-1",
+       "prec-1-2",
+       "prec-2-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-second-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-2A",
+       "prec-5-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-eighteenth-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-3",
+       "prec-2-1",
+       "prec-2-2",
+       "prec-2-3A",
+       "prec-3-1",
+       "prec-3-2",
+       "prec-3-3",
+       "prec-4-1",
+       "prec-5-1",
+       "prec-5-3",
+       "prec-6-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-10-1",
+       "prec-10-3",
+       "prec-11-1A",
+       "prec-11-2",
+       "prec-11-3A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-3-3A",
+       "prec-4-2",
+       "prec-6-2",
+       "prec-6-3",
+       "prec-7-2",
+       "prec-7-3",
+       "prec-8-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-4-2A",
+       "prec-4-3",
+       "prec-7-2A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-6-1A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-7-1",
+       "prec-8-1",
+       "prec-10-1A",
+       "prec-10-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-8-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-9-1",
+       "prec-9-2",
+       "prec-9-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-governor-and-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-1",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-2",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-3",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-4",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-5",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "bmc-question-6",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "@type" : "ElectionResults.BallotStyle" } ],
+    "Candidate" : 
+    [ 
+     { "@id" : "can-a-joy-campbell",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "ANDREA JOY CAMPBELL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-a-amore",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "ANTHONY AMORE",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-a-s-pressley",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "AYANNA S. PRESSLEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-c-colarusso",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "CAROLINE COLARUSSO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-c-crawford",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "CRISTINA CRAWFORD",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-lib",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-joseph-ryan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DANIEL JOSEPH RYAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-werner-riek",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DANIEL WERNER RIEK",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-lib",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-m-rogers",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DAVID M. ROGERS",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-b-goldberg",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DEBORAH B. GOLDBERG",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-dizoglio",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DIANA DiZOGLIO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-and-allen",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DIEHL AND ALLEN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-giannone-iii",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DOMINIC GIANNONE, III",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-wor",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-dionicio-palmer-jr",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DONNIE DIONICIO PALMER, JR.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-g-a-caballero-roca",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "GLORIA A. CABALLERO-ROCA",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-gre",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-h-and-driscoll",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "HEALEY AND DRISCOLL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-j-r-mcmahon-iii",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "JAMES R. McMAHON, III",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-j-sanchez",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "JUAN SANCHEZ",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-gre",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-k-m-clark",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "KATHERINE M. CLARK",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-t-ryan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARIAN T. RYAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-m-petitto-devaney",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARILYN M. PETITTO DEVANEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-c-decker",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARJORIE C. DECKER",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-j-moran",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MICHAEL J. MORAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-connolly",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MIKE CONNOLLY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-p-d-jehlen",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "PATRICIA D. JEHLEN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-p-j-koutoujian",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "PETER J. KOUTOUJIAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-r-campbell",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "RAYLA CAMPBELL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-r-and-everett",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "REED AND EVERETT",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-lib",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-n-didomenico",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "SAL N. DiDOMENICO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-c-owens",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "STEVEN C. OWENS",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-t-w-kennedy",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "TERRENCE W. KENNEDY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-w-francis-galvin",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "WILLIAM FRANCIS GALVIN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-w-n-brownsberger",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "WILLIAM N. BROWNSBERGER",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" } ],
+    "Contest" : 
+    [ 
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-governor-and-lieutenant-governor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-and-allen" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-and-allen",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 144,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 97,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 41,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 72,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 49,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 130,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 142,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 48,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 97,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-h-and-driscoll" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-h-and-driscoll",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 549,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 257,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 932,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1000,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 904,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 821,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 740,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1021,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 670,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 381,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1313,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1051,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 172,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1191,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1082,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1073,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1028,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 323,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 693,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1368,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1222,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 802,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 303,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1128,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 275,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1828,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1305,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 958,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 613,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1627,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1098,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 390,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 448,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 713,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1188,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 140,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-r-and-everett" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-r-and-everett",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-governor-and-lieutenant-governor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "GOVERNOR AND LIEUTENANT GOVERNOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-attorney-general-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-joy-campbell" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-joy-campbell",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 537,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 253,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 926,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 999,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 886,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 813,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 738,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1018,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 660,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 379,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1295,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1046,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 168,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1185,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1079,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1066,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1020,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 320,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 689,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1354,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1210,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 797,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 302,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1084,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1098,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 276,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1806,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1294,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 958,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 600,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1604,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1095,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 391,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 445,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 720,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1181,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-j-r-mcmahon-iii" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-j-r-mcmahon-iii",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 41,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 164,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 107,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 73,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 72,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 73,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 150,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 163,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 53,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 99,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-attorney-general-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "ATTORNEY GENERAL",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-secretary-of-state-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-w-francis-galvin" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-w-francis-galvin",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 539,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 248,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 912,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 963,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 866,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 803,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 707,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 971,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 621,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 363,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1228,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1003,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 151,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1013,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 145,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1014,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 955,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 310,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 677,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1297,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1137,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 764,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 278,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1050,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1074,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 257,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1765,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1241,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1252,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 906,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 580,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1520,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1061,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 379,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 430,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 702,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1138,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-r-campbell" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-r-campbell",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 42,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 106,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 123,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 54,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 116,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-j-sanchez" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-j-sanchez",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 68,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 94,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 61,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 87,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 49,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 72,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 97,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-secretary-of-state-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "SECRETARY OF STATE",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-treasurer-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-b-goldberg" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-b-goldberg",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 534,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 255,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 925,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 999,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 902,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 814,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 719,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 994,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 646,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 370,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1281,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1015,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 166,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1168,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1067,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1045,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 995,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 317,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 680,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1345,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1209,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 796,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 302,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1069,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1092,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 280,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1784,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1288,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1271,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 942,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 602,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1571,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1087,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 394,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 447,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 708,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1167,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 130,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-c-crawford" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-c-crawford",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 96,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 67,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 73,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 53,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 106,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 61,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-treasurer-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "TREASURER",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 77,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 67,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 57,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 77,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 105,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 94,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 84,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 78,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-auditor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-amore" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-amore",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 99,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 185,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 145,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 124,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 127,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 267,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 183,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 198,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 106,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 154,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 165,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-d-dizoglio" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-dizoglio",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 438,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 208,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 755,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 837,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 728,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 660,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 623,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 858,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 535,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 319,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1068,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 840,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 951,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 872,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 896,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 849,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 265,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 575,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1117,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 976,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 664,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 243,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 896,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 908,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 218,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1493,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1092,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1051,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 795,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 498,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1334,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 927,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 328,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 616,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 986,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 111,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-g-a-caballero-roca" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-g-a-caballero-roca",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 54,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 49,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 97,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 61,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 54,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-d-giannone-iii" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-giannone-iii",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 46,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-d-werner-riek" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-werner-riek",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-auditor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "AUDITOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 75,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 69,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 67,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 77,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 76,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 81,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-congress-fifth",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-k-m-clark" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-k-m-clark",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 376,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1041,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 320,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 690,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1364,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 794,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 299,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1080,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 278,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1797,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1304,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1269,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 602,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1597,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1185,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-c-colarusso" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-c-colarusso",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 100,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 71,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 142,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 151,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 49,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 116,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-congress-fifth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-6",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-congress-seventh",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-s-pressley" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-s-pressley",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 538,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 239,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 908,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 982,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 878,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 783,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 727,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1006,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 658,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1274,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 162,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1166,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1059,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 154,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1055,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 989,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 931,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1088,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 389,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 444,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 708,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-d-dionicio-palmer-jr" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-dionicio-palmer-jr",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 129,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 111,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-congress-seventh-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-8",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-councillor-sixth",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-t-w-kennedy" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-t-w-kennedy",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 537,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 238,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 916,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 970,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 849,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 790,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 687,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 945,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 599,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 358,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1183,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 959,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 155,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1075,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 974,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 140,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 990,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 925,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 297,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 636,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1241,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1120,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 724,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 291,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 995,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 260,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 853,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 545,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1422,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1007,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 378,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 419,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 693,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1090,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-councillor-sixth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-17",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 172,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 182,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 228,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 150,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 150,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 175,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 125,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 248,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 175,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 207,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 213,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 173,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 115,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 258,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 194,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 166,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 181,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 193,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 122,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 303,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 215,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 57,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 100,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 125,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 236,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-councillor-third",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-m-petitto-devaney" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-m-petitto-devaney",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 973,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1599,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1201,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1192,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-councillor-third-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-14",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 229,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 381,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 272,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 275,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-senator-in-general-court-second-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-p-d-jehlen" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-p-d-jehlen",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1027,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 892,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 576,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1493,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1027,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 382,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 433,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 692,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1140,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-senator-in-general-court-second-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-34",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 165,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 152,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 157,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 91,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 232,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 193,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 126,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 189,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-senator-in-general-court-suffolk-n-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-w-n-brownsberger" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-w-n-brownsberger",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1005,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1674,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1241,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1218,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-senator-in-general-court-suffolk-n-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1332",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 198,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 317,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 235,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 255,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-senator-in-general-court-middlesex-n-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-s-n-didomenico" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-n-didomenico",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 533,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 239,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 935,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 987,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 875,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 792,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 691,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 949,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 609,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 364,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1178,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 965,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 154,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1073,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 977,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 142,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 994,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 950,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 296,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 634,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1259,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 725,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 293,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 257,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-senator-in-general-court-middlesex-n-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1311",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 91,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 149,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 165,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 204,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 145,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 171,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 116,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 255,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 208,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 212,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 173,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 143,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 117,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 243,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 163,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-second-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-joseph-ryan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-joseph-ryan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 530,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 788,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-second-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-185",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 95,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 149,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-twenty-fourth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-m-rogers" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-m-rogers",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 380,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1143,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-twenty-fourth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-141",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 190,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-twenty-sixth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-connolly" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-connolly",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 924,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 987,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 863,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 686,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 962,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 613,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1189,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 993,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1006,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 929,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 295,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-twenty-sixth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-143",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 159,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 163,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 213,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 150,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 158,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 110,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 244,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 195,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 159,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 162,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-twenty-ninth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-s-c-owens" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-c-owens",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1661,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1226,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1230,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 870,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1008,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 423,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 671,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 123,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-twenty-ninth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-146",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 328,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 252,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 242,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 179,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 214,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 98,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-twenty-fifth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-c-decker" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-c-decker",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 356,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 968,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 156,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1096,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 643,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1254,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1144,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 730,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 290,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1024,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1014,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 259,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 559,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1496,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-twenty-fifth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-142",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 167,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 185,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 108,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 250,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 161,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 154,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 189,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 106,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 231,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-representative-in-general-court-eighteenth-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-j-moran" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-j-moran",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 141,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-representative-in-general-court-eighteenth-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-201",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-district-attorney-northern",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-t-ryan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-t-ryan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 529,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 239,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 903,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 952,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 850,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 795,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 681,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 943,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 598,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 355,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1184,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 960,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1073,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 967,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 141,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 994,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 925,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 294,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 637,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1239,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 733,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 289,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1010,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 990,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 255,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1661,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1225,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 861,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 554,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1466,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1015,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 427,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 676,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-district-attorney-northern-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-912",
+      "Name" : "DISTRICT ATTORNEY",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 95,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 183,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 199,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 231,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 145,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 156,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 178,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 127,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 251,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 173,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 209,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 219,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 174,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 263,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 191,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 161,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 211,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 326,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 249,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 256,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 187,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 112,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 263,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 206,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 94,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 143,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 212,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-sheriff-middlesex-county",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-p-j-koutoujian" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-p-j-koutoujian",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 535,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 236,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 891,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 949,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 837,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 776,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 684,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 918,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 580,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 352,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 933,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 147,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1040,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 943,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 136,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 978,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 903,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 291,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 630,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1210,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1091,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 720,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 282,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 973,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 986,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 255,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1626,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1210,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 846,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 533,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1419,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 988,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 373,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 422,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 668,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1096,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-sheriff-middlesex-county-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-911",
+      "Name" : "SHERIFF",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 91,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 192,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 201,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 244,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 163,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 152,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 202,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 145,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 274,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 196,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 242,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 241,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 189,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 189,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 122,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 291,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 223,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 173,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 205,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 216,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 359,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 262,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 263,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 203,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 135,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 305,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 232,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 99,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 234,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "This proposed constitutional amendment would establish an additional 4% state income tax on that portion of annual taxable income in excess of $1 million. This income level would be adjusted annually, by the same method used for federal income-tax brackets, to reflect increases in the cost of living. Revenues from this tax would be used, subject to appropriation by the state Legislature, for public education, public colleges and universities; and for the repair and maintenance of roads, bridges, and public transportation. The proposed amendment would apply to tax years beginning on or after January 1, 2023.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-1",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-1-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 429,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 207,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 800,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 862,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 730,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 663,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 628,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 900,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 592,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 342,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1080,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 901,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 996,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 948,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 138,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 911,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 875,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 278,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 582,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1040,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 671,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 274,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 907,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 826,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 243,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1288,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1045,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1037,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 835,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 486,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1281,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 919,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 347,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 397,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 594,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1028,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-1-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 184,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 262,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 250,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 329,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 260,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 169,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 204,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 67,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 326,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 202,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 241,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 205,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 242,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 200,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 329,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 255,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 210,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 243,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 350,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 662,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 404,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 414,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 206,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 162,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 414,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 259,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 175,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 288,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "ADDITIONAL TAX ON INCOME OVER 1 MILLION DOLLARS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "This proposed law would direct the Commissioner of the Massachusetts Division of Insurance to approve or disapprove the rates of dental benefit plans and would require that a dental insurance carrier meet an annual aggregate medical loss ratio for its covered dental benefit plans of 83 percent. The medical loss ratio would measure the amount of premium dollars a dental insurance carrier spends on its members' dental expenses and quality improvements, as opposed to administrative expenses. If a carrier's annual aggregate medical loss ratio is less than 83 percent, the carrier would be required to refund the excess premiums to its covered individuals and groups. The proposed law would allow the Commissioner to waive or adjust the refunds only if it is determined that issuing refunds would result in financial impairment for the carrier. The proposed law would apply to dental benefit plans regardless of whether they are issued directly by a carrier, through the connector, or through an intermediary. The proposed law would not apply to dental benefit plans issued, delivered, or renewed to a self-insured group or where the carrier is acting as a third-party administrator. The proposed law would require the carriers offering dental benefit plans to submit information about their current and projected medical loss ratio, administrative expenses, and other financial information to the Commissioner. Each carrier would be required to submit an annual comprehensive financial statement to the Division of Insurance, itemized by market group size and line of business. A carrier that also provides administrative services to one or more self-insured groups would also be required to file an appendix to their annual financial statement with information about its self-insured business. The proposed law would impose a late penalty on a carrier that does not file its annual report on or before April 1. The Division would be required to make the submitted data public, to issue an annual summary to certain legislative committees, and to exchange the data with the Health Policy Commission. The Commissioner would be required to adopt standards requiring the registration of persons or entities not otherwise licensed or registered by the Commissioner and criteria for the standardized reporting and uniform allocation methodologies among carriers. The proposed law would allow the Commissioner to approve dental benefit policies for the purpose of being offered to individuals or groups. The Commissioner would be required to adopt regulations to determine eligibility criteria. The proposed law would require carriers to file group product base rates and any changes to group rating factors that are to be effective on January 1 of each year on or before July 1 of the preceding year. The Commissioner would be required to disapprove any proposed changes to base rates that are excessive, inadequate, or unreasonable in relation to the benefits charged. The Commissioner would also be required to disapprove any change to group rating factors that is discriminatory or not actuarially sound. The proposed law sets forth criteria that, if met, would require the Commissioner to presumptively disapprove a carrier's rate, including if the aggregate medical loss ratio for all dental benefit plans offered by a carrier is less than 83 percent. The proposed law would establish procedures to be followed if a proposed rate is presumptively disapproved or if the Commissioner disapproves a rate. The proposed law would require the Division to hold a hearing if a carrier reports a risk-based capital ratio on a combined entity basis that exceeds 700 percent in its annual report. The proposed law would require the Commissioner to promulgate regulations consistent with its provisions by October 1, 2023. The proposed law would apply to all dental benefit plans issued, made effective, delivered, or renewed on or after January 1, 2024.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-2",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-2-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 509,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 249,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 875,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 929,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 869,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 750,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 664,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 948,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 635,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 358,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1195,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 965,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 156,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1057,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 987,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 126,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 984,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 904,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 300,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 624,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1254,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 732,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 284,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 981,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 968,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1604,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1213,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1219,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 883,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 553,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1441,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1011,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 357,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 426,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 619,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-2-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 41,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 170,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 175,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 178,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 159,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 128,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 45,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 188,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 157,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 150,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 87,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 180,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 159,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 131,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 189,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 297,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 214,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 222,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 209,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 144,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 130,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 179,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "PET I: DENTAL BENEFITS (LAW)",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 57,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 76,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 93,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 83,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 72,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "This proposed law would increase the statewide limits on the combined number of licenses for the sale of alcoholic beverages for off-premises consumption (including licenses for 'all alcoholic beverages' and for 'wines and malt beverages') that any one retailer could own or control: from 9 to 12 licenses in 2023; to 15 licenses in 2027; and to 18 licenses in 2031. Beginning in 2023, the proposed law would set a maximum number of 'all alcoholic beverages' licenses that any one retailer could own or control at 7 licenses unless a retailer currently holds more than 7 such licenses. The proposed law would require retailers to conduct the sale of alcoholic beverages for off-premises consumption through face-to-face transactions and would prohibit automated or self-checkout sales of alcoholic beverages by such retailers. The proposed law would alter the calculation of the fine that the Alcoholic Beverages Control Commission may accept in lieu of suspending any license issued under the State Liquor Control Act. The proposed law would modify the formula for calculating such fee from being based on the gross profits on the sale of alcoholic beverages to being based on the gross profits on all retail sales. The proposed law would also add out-of-state motor vehicle licenses to the list of the forms of identification that any holder of a license issued under the State Liquor Control Act, or their agent or employee, may choose to reasonably rely on for proof of a person's identity and age.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-3",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-3-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 355,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 584,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 635,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 570,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 521,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 444,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 653,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 422,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 259,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 856,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 648,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 106,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 728,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 717,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 674,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 634,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 206,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 426,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 839,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 774,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 472,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 200,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 645,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 658,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 184,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1124,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 792,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 754,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 604,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 387,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 970,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 667,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 251,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 277,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 392,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 705,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 92,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-3-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 243,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 130,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 449,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 441,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 446,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 372,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 306,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 388,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 249,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 123,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 487,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 385,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 440,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 385,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 413,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 371,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 249,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 536,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 446,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 336,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 430,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 450,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 719,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 590,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 640,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 389,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 231,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 605,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 452,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 150,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 203,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 344,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 546,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "PET D: ALCOHOL RETAIL REFORM (LAW)",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 57,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 82,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 92,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 85,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 93,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 103,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 116,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 84,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 89,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 83,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 135,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 96,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 87,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 107,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 101,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 151,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 105,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 85,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 158,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 106,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 85,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 86,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "This law allows Massachusetts residents who cannot provide proof of lawful presence in the United States to obtain a standard driver's license or learner's permit if they meet all the other qualifications for a standard license or learner's permit, including a road test and insurance, and provide proof of their identity, date of birth, and residency. The law provides that, when processing an application for such a license or learner's permit or motor vehicle registration, the registrar of motor vehicles may not ask about or create a record of the citizenship or immigration status of the applicant, except as otherwise required by law. This law does not allow people who cannot provide proof of lawful presence in the United States to obtain a REAL ID. To prove identity and date of birth, the law requires an applicant to present at least two documents, one from each of the following categories: (1) a valid unexpired foreign passport or a valid unexpired Consular Identification document; and (2) a valid unexpired driver's license from any United States state or territory, an original or certified copy of a birth certificate, a valid unexpired foreign national identification card, a valid unexpired foreign driver's license, or a marriage certificate or divorce decree issued by any state or territory of the United States. One of the documents presented by an applicant must include a photograph and one must include a date of birth. Any documents not in English must be accompanied by a certified translation. The registrar may review any documents issued by another country to determine whether they may be used as proof of identity or date of birth. The law requires that applicants for a driver's license or learner's permit shall attest, under the pains and penalties of perjury, that their license has not been suspended or revoked in any other state, country, or jurisdiction. The law specifies that information provided by or relating to any applicant or license-holder will not be a public record and shall not be disclosed, except as required by federal law or as authorized by Attorney General regulations, and except for purposes of motor vehicle insurance. The law directs the registrar of motor vehicles to make regulations regarding the documents required of United States citizens and others who provide proof of lawful presence with their license application. The law also requires the registrar and the Secretary of the Commonwealth to establish procedures and regulations to ensure that an applicant for a standard driver's license or learner's permit who does not provide proof of lawful presence will not be automatically registered to vote. The law takes effect on July 1, 2023.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-4",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-4-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 482,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 838,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 900,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 822,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 744,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 71,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 625,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 950,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 617,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 345,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1203,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 959,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 159,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1074,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1017,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 145,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1003,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 944,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 306,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 647,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1293,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1157,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 751,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 286,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1012,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1012,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 262,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1692,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1182,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1173,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 891,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 560,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1488,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 991,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 354,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 417,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 602,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1087,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-4-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 217,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 214,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 237,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 178,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 166,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 87,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 197,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 161,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 130,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 129,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 185,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 124,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 127,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 158,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 252,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 261,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 279,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 91,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 196,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 179,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 68,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 162,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 221,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "REF: REPEAL DRIVER'S LICENSE LAW",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 57,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-5",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-5-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 315,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 878,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 146,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 988,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 584,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1024,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 691,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 267,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 877,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 844,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 236,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 503,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1270,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-5-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 142,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 138,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 100,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 194,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 172,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 194,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 94,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 252,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "PPQ REP - 25TH MIDDLESEX DISTRICT - SINGLE PAYER HEALTH CARE",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 116,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 158,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 74,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 168,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 120,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 86,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 156,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 171,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 72,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 211,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "SummaryText" : 
+      { "Text" : 
+       [ 
+        { "Content" : "",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "@type" : "ElectionResults.BallotMeasureContest",
+      "@id" : "bmc-question-6",
+      "ContestSelection" : 
+      [ 
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "YES",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-6-yes",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 349,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 969,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1031,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 639,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1272,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1117,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 764,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 290,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 988,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 987,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 256,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 557,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1460,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] },
+       
+       { "Selection" : 
+        { "Text" : 
+         [ 
+          { "Content" : "NO",
+           "Language" : "en",
+           "@type" : "ElectionResults.LanguageString" } ],
+         "@type" : "ElectionResults.InternationalizedText" },
+        "@type" : "ElectionResults.BallotMeasureSelection",
+        "@id" : "bms-question-6-no",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 48,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 73,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 61,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "PPQ REP - 25TH MIDDLESEX DISTRICT - COMMITTEE VOTES ONLINE",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 119,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 167,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 79,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 165,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 136,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 87,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 144,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 161,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 74,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 191,
+        "@type" : "ElectionResults.OtherCounts" } ] } ],
+    "ElectionScopeId" : "loc-cambridge",
+    "EndDate" : "2022-11-08",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "General Election",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "StartDate" : "2022-11-08",
+    "Type" : "general",
+    "@type" : "ElectionResults.Election" } ],
+  "Format" : "precinct-level",
+  "GeneratedDate" : "2023-05-02T00:00:00Z",
+  "GpUnit" : 
+  [ 
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "city",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "loc-cambridge",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Cambridge",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "congressional",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-6",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1A",
+     "prec-10-2",
+     "prec-11-3",
+     "prec-3-3A",
+     "prec-4-2",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "FIFTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "congressional",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-8",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-4-1",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-7-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SEVENTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "OtherType" : "gov-council",
+    "Type" : "other",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-14",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "THIRD DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "OtherType" : "gov-council",
+    "Type" : "other",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-17",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SIXTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-34",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-7-1",
+     "prec-8-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SECOND MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-141",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-1",
+     "prec-11-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-FOURTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-142",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1A",
+     "prec-10-2",
+     "prec-3-3A",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-FIFTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-143",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-4-1",
+     "prec-5-1",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-SIXTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-146",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-3",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3A",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-NINTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-185",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-2-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SECOND SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-201",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-2A",
+     "prec-5-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "EIGHTEENTH SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "county",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-911",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MIDDLESEX COUNTY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "judicial",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-912",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "NORTHERN DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-1311",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MIDDLESEX & SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-1332",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SUFFOLK & MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "CONFERENCE CENTER" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-222-jacobs-street",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "222 JACOBS STREET",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "COMMUNITY FLOOR, 85 OXFORD ST, SACRAMENTO ST ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-baldwin-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "BALDWIN SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "50 CHURCHILL AVENUE, COMMUNITY ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-burns-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "BURNS APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "66 SHERMAN STREET, PATIO ENTRANCE ON CADBURY RD" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cadbury-commons",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CADBURY COMMONS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "459 BROADWAY, MEDIA CAFETERIA, CAMBRIDGE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-rindge--latin",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE RINDGE & LATIN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "459 BROADWAY, MEDIA CAFETERIA, CAMBRIDGE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-rindge--latin-",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE RINDGE & LATIN ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "250 FRESH POND PARKWAY" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-water-departmen",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE WATER DEPARTMEN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "344 BROADWAY, 2ND FLOOR CONFERENCE ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-city-hall-annex",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-1",
+     "prec-6-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CITY HALL ANNEX",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "795 MASSACHUSETTS AVE, DRIVEWAY ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-city-hall-basement",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-3",
+     "prec-3-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CITY HALL BASEMENT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "5 LONGFELLOW PARK, COMMUNITY ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-friends-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "FRIENDS CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "44 LINNAEAN ST., PLAYGROUND ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-graham--parks-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-1",
+     "prec-10-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "GRAHAM & PARKS SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "48 QUINCY STREET, CAMBRIDGE ST. ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-gund-hl-harv-design-sch",
+    "ComposingGpUnitIds" : 
+    [ "prec-7-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "GUND HL, HARV DESIGN SCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "167 LEXINGTON AVENUE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-lexington-ave-fire-house",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "LEXINGTON AVE FIRE HOUSE",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "BEHIND STRATTON STUDENT CENTER (70 MASS AVE)" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-mit-kresge-auditorium",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-2",
+     "prec-1-2A",
+     "prec-5-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "M.I.T. KRESGE AUDITORIUM",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "102 PUTNAM AVENUE, PLAYGROUND GYM ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-martin-luther-king-jr-sch",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-3",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MARTIN LUTHER KING JR SCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "15 LAMBERT STREET, CAMBRIDGE ST. ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-millers-river-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MILLERS RIVER APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "40 GRANITE ST, MAIN ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-morse-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-1",
+     "prec-5-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MORSE SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "243 HARVARD ST, FRONT ENTRANCE " ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-moses-youth-center-",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MOSES YOUTH CENTER ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "48 SIXTH ST, CORNER OF THORNDIKE ST, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-onconnell-branch-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-3",
+     "prec-2-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "O'CONNELL BRANCH LIBRARY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "70 RINDGE AVE, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-peabody-school-gym",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "PEABODY SCHOOL GYM",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "131 WASHINGTON STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-pisani-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "PISANI CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "170 RINDGE AVENUE, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-reservoir-church",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "RESERVOIR CHURCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "680 HURON AVENUE, SECOND FLOOR" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-russell-youth-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "RUSSELL YOUTH CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "402 MASSCHUSETTS AVE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-salvation-army",
+    "ComposingGpUnitIds" : 
+    [ "prec-5-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SALVATION ARMY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "838 MASSACHUSETTS AVE, ENTRANCE ON SELLERS STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-st-peterns-episcopal-chur",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-2",
+     "prec-4-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "ST PETER'S EPISCOPAL CHUR",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "25 EIGHTH ST, COMMUNITY ROOM, THORNDIKE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-truman-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TRUMAN APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "826 CAMBRIDGE ST, SIDE ENTRANCE ON BERKSHIRE STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-valente-branch-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "VALENTE BRANCH LIBRARY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "250 Fresh Pond Parkway" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-water-department",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Cambridge Water Department",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "449 Broadway" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-main-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Main Library",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "826 Cambridge Street, Side Entrance on Berkshire Street" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-valente-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Valente Library",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } } ],
+  "Issuer" : "NIST Test Data",
+  "IssuerAbbreviation" : "NIST",
+  "Party" : 
+  [ 
+   { "@id" : "par-rep",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "REPUBLICAN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" },
+   
+   { "@id" : "par-dem",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "DEMOCRAT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" },
+   
+   { "@id" : "par-gre",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "GREEN-RAINBOW",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" },
+   
+   { "@id" : "par-wor",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "WORKERS PARTY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" },
+   
+   { "@id" : "par-lib",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "LIBERTARIAN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" } ],
+  "SequenceEnd" : 1,
+  "SequenceStart" : 1,
+  "Status" : "certified",
+  "VendorApplicationId" : "MA Export",
+  "@type" : "ElectionResults.ElectionReport" }

--- a/test_data/real_world/ma/cambridge/2022/primary/err_v2/err-2022-09-06-Massachusetts-Cambridge.json
+++ b/test_data/real_world/ma/cambridge/2022/primary/err_v2/err-2022-09-06-Massachusetts-Cambridge.json
@@ -1,0 +1,23505 @@
+
+ { "Election" : 
+  [ 
+   { "BallotCounts" : 
+    [ 
+     { "BallotsCast" : 214,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 14,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 119,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 20,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 0,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 414,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 43,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-1-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 434,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 34,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 461,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 45,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 333,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 25,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 36,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-2-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 293,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 23,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 413,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 14,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 299,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 11,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 151,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 5,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-3-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 677,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 31,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 474,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 16,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 74,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 4,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 518,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 23,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-4-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 485,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 18,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 33,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 462,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 29,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-5-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 452,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 18,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 175,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 5,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 304,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 16,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 673,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 34,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-6-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 578,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 20,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 360,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 15,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 16,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 1,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-2A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 137,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 9,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-7-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 549,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 25,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 541,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 34,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 104,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 4,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-8-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 962,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 48,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 706,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 47,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 653,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 36,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-9-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 521,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 29,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 314,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 14,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 911,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 30,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 584,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 28,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-10-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 148,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 11,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 209,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 8,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-1A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 325,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 21,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-2",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 628,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 45,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 92,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3A",
+      "Type" : "total" },
+     
+     { "BallotsCast" : 4,
+      "@type" : "ElectionResults.BallotCounts",
+      "GpUnitId" : "prec-11-3A",
+      "Type" : "total" } ],
+    "BallotStyle" : 
+    [ 
+     { "GpUnitIds" : 
+      [ "prec-8-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-8-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-11-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fourth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-6-1A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-6-1A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-2A",
+       "prec-5-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-eighteenth-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-2A",
+       "prec-5-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-eighteenth-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-1",
+       "prec-1-2",
+       "prec-2-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-second-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-1",
+       "prec-1-2",
+       "prec-2-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-second-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-9-1",
+       "prec-9-2",
+       "prec-9-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-9-1",
+       "prec-9-2",
+       "prec-9-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-third",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-suffolk-n-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-4-2A",
+       "prec-4-3",
+       "prec-7-2A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-4-2A",
+       "prec-4-3",
+       "prec-7-2A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-7-1",
+       "prec-8-1",
+       "prec-10-1A",
+       "prec-10-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-7-1",
+       "prec-8-1",
+       "prec-10-1A",
+       "prec-10-2" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-10-1",
+       "prec-10-3",
+       "prec-11-1A",
+       "prec-11-2",
+       "prec-11-3A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-10-1",
+       "prec-10-3",
+       "prec-11-1A",
+       "prec-11-2",
+       "prec-11-3A" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-second-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-ninth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-3-3A",
+       "prec-4-2",
+       "prec-6-2",
+       "prec-6-3",
+       "prec-7-2",
+       "prec-7-3",
+       "prec-8-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-3-3A",
+       "prec-4-2",
+       "prec-6-2",
+       "prec-6-3",
+       "prec-7-2",
+       "prec-7-3",
+       "prec-8-3" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-fifth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-fifth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-3",
+       "prec-2-1",
+       "prec-2-2",
+       "prec-2-3A",
+       "prec-3-1",
+       "prec-3-2",
+       "prec-3-3",
+       "prec-4-1",
+       "prec-5-1",
+       "prec-5-3",
+       "prec-6-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-dem-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-dem-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-dem" ],
+      "@type" : "ElectionResults.BallotStyle" },
+     
+     { "GpUnitIds" : 
+      [ "prec-1-3",
+       "prec-2-1",
+       "prec-2-2",
+       "prec-2-3A",
+       "prec-3-1",
+       "prec-3-2",
+       "prec-3-3",
+       "prec-4-1",
+       "prec-5-1",
+       "prec-5-3",
+       "prec-6-1" ],
+      "OrderedContent" : 
+      [ 
+       { "ContestId" : "cc-rep-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-lieutenant-governor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-attorney-general-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-secretary-of-state-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-treasurer-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-auditor-statewide",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-congress-seventh",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-councillor-sixth",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-representative-in-general-court-twenty-sixth-middlesex",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-district-attorney-northern",
+        "@type" : "ElectionResults.OrderedContest" },
+       
+       { "ContestId" : "cc-rep-sheriff-middlesex-county",
+        "@type" : "ElectionResults.OrderedContest" } ],
+      "PartyIds" : 
+      [ "par-rep" ],
+      "@type" : "ElectionResults.BallotStyle" } ],
+    "Candidate" : 
+    [ 
+     { "@id" : "can-a-joy-campbell",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "ANDREA JOY CAMPBELL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-a-amore",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "ANTHONY AMORE",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-a-s-pressley",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "AYANNA S. PRESSLEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-c-colarusso",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "CAROLINE COLARUSSO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-c-doughty",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "CHRIS DOUGHTY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-c-s-dempsey",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "CHRISTOPHER S. DEMPSEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-joseph-ryan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DANIEL JOSEPH RYAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-m-rogers",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DAVID M. ROGERS",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-b-goldberg",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DEBORAH B. GOLDBERG",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-dizoglio",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DIANA DiZOGLIO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-d-dionicio-palmer-jr",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "DONNIE DIONICIO PALMER, JR.",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-e-p-lesser",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "ERIC P. LESSER",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-f-glynn",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "FREDERICK GLYNN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-g-diehl",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "GEOFF DIEHL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-j-r-mcmahon-iii",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "JAMES R. McMAHON, III",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-k-campanale",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "KATE CAMPANALE",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-k-m-clark",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "KATHERINE M. CLARK",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-k-driscoll",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "KIMBERLEY DRISCOLL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-l-v-allen",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "LEAH V. ALLEN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-dolan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARA DOLAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-t-ryan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARIAN T. RYAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-m-petitto-devaney",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARILYN M. PETITTO DEVANEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-c-decker",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARJORIE C. DECKER",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-i-holt",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MARK I. HOLT",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-healey",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MAURA HEALEY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-j-moran",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MICHAEL J. MORAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-m-connolly",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "MIKE CONNOLLY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-p-d-jehlen",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "PATRICIA D. JEHLEN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-p-j-koutoujian",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "PETER J. KOUTOUJIAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-q-palfrey",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "QUENTIN PALFREY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-r-campbell",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "RAYLA CAMPBELL",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-rep",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-n-didomenico",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "SAL N. DiDOMENICO",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-erika-liss-riordan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "SHANNON ERIKA LISS-RIORDAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-rosa-chang-diaz",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "SONIA ROSA CHANG-DIAZ",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-s-c-owens",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "STEVEN C. OWENS",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-t-gouveia",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "TAMI GOUVEIA",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-t-m-sullivan",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "TANISHA M. SULLIVAN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-t-w-kennedy",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "TERRENCE W. KENNEDY",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-w-francis-galvin",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "WILLIAM FRANCIS GALVIN",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" },
+     
+     { "@id" : "can-w-n-brownsberger",
+      "BallotName" : 
+      { "Text" : 
+       [ 
+        { "Content" : "WILLIAM N. BROWNSBERGER",
+         "Language" : "en",
+         "@type" : "ElectionResults.LanguageString" } ],
+       "@type" : "ElectionResults.InternationalizedText" },
+      "PartyId" : "par-dem",
+      "@type" : "ElectionResults.Candidate" } ],
+    "Contest" : 
+    [ 
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-governor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-s-rosa-chang-diaz" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-rosa-chang-diaz",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 41,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 105,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 67,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 42,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 49,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-m-healey" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-healey",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 105,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 321,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 338,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 376,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 287,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 191,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 322,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 131,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 560,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 389,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 417,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 385,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 380,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 379,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 266,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 572,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 487,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 313,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 116,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 462,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 481,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 892,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 611,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 564,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 424,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 266,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 817,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 477,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 169,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 245,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 497,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-governor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "GOVERNOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-governor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-g-diehl" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-g-diehl",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-c-doughty" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-c-doughty",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-governor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "GOVERNOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-lieutenant-governor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-k-driscoll" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-k-driscoll",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 92,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 42,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 186,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 197,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 144,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 172,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 282,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 170,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 238,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 204,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 207,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 186,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 282,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 228,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 226,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 374,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 332,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 273,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 212,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 416,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 246,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 57,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 80,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 151,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 287,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-t-gouveia" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-t-gouveia",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 111,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 141,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 81,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 44,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 178,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 140,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 136,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 123,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 134,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 83,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 178,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 152,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 97,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 120,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 110,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 167,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 164,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 161,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 156,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 94,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 202,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 152,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 152,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-e-p-lesser" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-e-p-lesser",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 45,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 87,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 159,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 98,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 105,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 106,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 79,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 163,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 151,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 42,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 154,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 154,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 307,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 157,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 177,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 107,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 224,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 146,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 71,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 146,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-lieutenant-governor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "LIEUTENANT GOVERNOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 53,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 69,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-lieutenant-governor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-l-v-allen" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-l-v-allen",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-k-campanale" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-k-campanale",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-lieutenant-governor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "LIEUTENANT GOVERNOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-attorney-general-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-joy-campbell" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-joy-campbell",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 213,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 251,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 244,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 170,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 166,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 264,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 441,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 276,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 335,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 303,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 278,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 273,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 109,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 179,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 350,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 318,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 596,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 421,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 386,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 312,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 186,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 567,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 334,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 120,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 176,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 363,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 59,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-s-erika-liss-riordan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-erika-liss-riordan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 128,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 92,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 100,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 51,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 139,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 124,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 117,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 127,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 107,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 71,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 191,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 150,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 143,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 145,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 194,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 187,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 161,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 135,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 89,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 207,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 164,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 107,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 177,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-q-palfrey" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-q-palfrey",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 43,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 38,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 46,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 53,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 47,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 71,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 72,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 67,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-attorney-general-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "ATTORNEY GENERAL",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-attorney-general-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-j-r-mcmahon-iii" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-j-r-mcmahon-iii",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 37,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-attorney-general-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "ATTORNEY GENERAL",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-secretary-of-state-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-w-francis-galvin" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-w-francis-galvin",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 118,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 64,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 232,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 204,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 228,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 195,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 174,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 100,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 305,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 229,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 218,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 196,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 199,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 207,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 148,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 337,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 290,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 287,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 520,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 349,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 351,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 247,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 150,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 446,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 277,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 58,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 92,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 183,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 282,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 40,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-t-m-sullivan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-t-m-sullivan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 88,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 167,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 220,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 216,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 131,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 152,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 221,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 193,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 351,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 234,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 42,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 280,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 268,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 253,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 226,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 84,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 144,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 313,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 277,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 175,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 245,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 206,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 63,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 401,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 335,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 290,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 261,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 159,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 436,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 293,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 87,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 112,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 333,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 52,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-secretary-of-state-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "SECRETARY OF STATE",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-secretary-of-state-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-r-campbell" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-r-campbell",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 21,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-secretary-of-state-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "SECRETARY OF STATE",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-treasurer-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-b-goldberg" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-b-goldberg",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 177,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 98,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 342,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 354,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 365,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 283,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 233,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 308,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 238,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 535,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 375,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 406,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 359,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 374,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 363,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 145,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 237,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 524,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 477,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 295,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 113,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 432,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 430,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 77,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 763,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 558,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 533,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 391,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 248,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 691,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 474,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 122,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 168,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 268,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 496,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-treasurer-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "TREASURER",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 72,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 80,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 93,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 104,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 141,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 98,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 112,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 125,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 87,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 86,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 65,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 146,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 101,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 65,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 115,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 110,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 198,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 145,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 118,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 130,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 64,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 217,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 109,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 130,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-treasurer-statewide",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-treasurer-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "TREASURER",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-auditor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-c-s-dempsey" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-c-s-dempsey",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 104,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 211,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 222,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 221,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 186,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 132,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 211,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 165,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 90,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 355,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 254,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 260,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 262,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 235,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 219,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 95,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 172,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 375,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 314,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 198,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 331,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 308,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 535,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 369,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 309,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 268,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 153,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 479,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 282,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 80,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 109,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 149,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-d-dizoglio" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-dizoglio",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 41,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 162,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 176,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 190,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 129,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 147,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 103,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 46,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 247,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 162,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 194,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 158,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 194,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 50,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 96,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 233,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 205,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 121,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 48,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 156,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 39,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 281,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 267,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 286,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 175,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 300,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 242,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 60,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 86,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 142,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 35,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-auditor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "AUDITOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 75,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 64,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 65,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 65,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 59,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 73,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 146,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 69,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 58,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 78,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 132,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 72,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-auditor-statewide",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-amore" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-amore",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 36,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 26,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 17,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 23,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 32,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 20,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-auditor-statewide-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "loc-cambridge",
+      "Name" : "AUDITOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-congress-fifth",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-k-m-clark" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-k-m-clark",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 410,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 156,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 262,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 561,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 507,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 308,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 482,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 476,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 82,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 846,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 608,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 574,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 273,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 793,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 516,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-congress-fifth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-6",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 109,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 66,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 97,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 77,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 38,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 115,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 108,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-congress-seventh",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-dionicio-palmer-jr" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-dionicio-palmer-jr",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 11,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 33,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 22,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 16,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 18,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 19,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-congress-seventh-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-8",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 2,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-congress-seventh",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-a-s-pressley" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-a-s-pressley",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 189,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 99,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 351,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 378,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 383,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 298,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 262,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 365,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 273,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 595,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 471,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 437,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 30,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 418,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 389,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 455,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 519,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 184,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 287,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 85,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-congress-seventh-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-8",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 78,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-congress-fifth",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-c-colarusso" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-c-colarusso",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 10,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 24,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 8,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 13,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 15,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 34,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 9,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-congress-fifth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-6",
+      "Name" : "REPRESENTATIVE IN CONGRESS",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 3,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 6,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-councillor-sixth",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-t-w-kennedy" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-t-w-kennedy",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 169,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 334,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 341,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 345,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 272,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 224,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 290,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 225,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 114,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 487,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 358,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 56,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 384,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 336,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 355,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 328,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 122,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 230,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 477,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 427,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 263,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 108,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 399,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 371,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 228,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 642,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 445,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 116,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 158,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 261,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 453,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-councillor-sixth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-17",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 80,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 92,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 115,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 61,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 121,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 72,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 189,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 134,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 149,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 107,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 124,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 74,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 193,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 149,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 96,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 84,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 266,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 138,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 171,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-councillor-third",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-f-glynn" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-f-glynn",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-m-i-holt" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-i-holt",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-councillor-third-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-14",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-councillor-third",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-m-petitto-devaney" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-m-petitto-devaney",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 200,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 374,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 276,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 292,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "CandidateIds" : 
+        [ "can-m-dolan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-dolan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 215,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 356,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 297,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 240,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-councillor-third-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-14",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 126,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 232,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 133,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 119,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-councillor-sixth",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-councillor-sixth-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-17",
+      "Name" : "COUNCILLOR",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-senator-in-general-court-second-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-p-d-jehlen" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-p-d-jehlen",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 474,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 443,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 428,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 260,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 738,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 496,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 120,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 176,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 274,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 524,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 76,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-senator-in-general-court-second-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-34",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 103,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 103,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 91,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 169,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 87,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 101,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 16,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-senator-in-general-court-suffolk-n-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-senator-in-general-court-suffolk-n-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1332",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-senator-in-general-court-suffolk-n-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-w-n-brownsberger" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-w-n-brownsberger",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 403,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 739,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 556,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 520,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-senator-in-general-court-suffolk-n-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1332",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 137,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 219,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 148,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 131,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-senator-in-general-court-middlesex-n-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-senator-in-general-court-middlesex-n-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1311",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-senator-in-general-court-middlesex-n-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-s-n-didomenico" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-n-didomenico",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 174,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 347,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 366,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 357,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 276,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 29,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 230,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 317,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 244,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 124,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 485,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 395,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 342,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 360,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 356,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 133,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 232,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 511,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 276,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 113,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 75,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-senator-in-general-court-middlesex-n-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-1311",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 39,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 67,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 102,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 7,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 63,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 96,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 55,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 192,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 97,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 122,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 142,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 102,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 96,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 41,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 160,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 81,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 24,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-senator-in-general-court-second-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-senator-in-general-court-second-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-34",
+      "Name" : "SENATOR IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-second-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-joseph-ryan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-joseph-ryan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 168,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 93,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 265,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-second-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-185",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 68,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-twenty-fourth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-twenty-fourth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-141",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-twenty-fourth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-d-m-rogers" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-d-m-rogers",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 510,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-twenty-fourth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-141",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 116,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-twenty-sixth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-twenty-sixth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-143",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-twenty-sixth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-connolly" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-connolly",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 335,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 366,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 248,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 336,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 247,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 520,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 374,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 372,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 351,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 140,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-twenty-sixth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-143",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 77,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 66,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 78,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 75,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 52,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 156,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 111,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 90,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 100,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-twenty-ninth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-twenty-ninth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-146",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 47,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-twenty-ninth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-s-c-owens" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-s-c-owens",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 728,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 545,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 518,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 388,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 456,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 169,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 263,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 69,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-twenty-ninth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-146",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 234,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 160,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 133,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 133,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 128,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-twenty-fifth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-twenty-fifth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-142",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-twenty-fifth-middlesex",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-c-decker" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-c-decker",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 123,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 385,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 65,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 436,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 247,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 528,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 484,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 288,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 14,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 115,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 461,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 440,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 78,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 257,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 766,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-twenty-fifth-middlesex-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-142",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 86,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 82,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 56,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 142,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 93,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 22,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 87,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 99,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 142,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-eighteenth-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-eighteenth-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-201",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-representative-in-general-court-eighteenth-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-j-moran" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-j-moran",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 27,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-representative-in-general-court-eighteenth-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-201",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-representative-in-general-court-second-suffolk",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-representative-in-general-court-second-suffolk-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-185",
+      "Name" : "REPRESENTATIVE IN GENERAL COURT",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-district-attorney-northern",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-m-t-ryan" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-m-t-ryan",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 171,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 96,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 333,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 352,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 345,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 281,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 31,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 232,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 303,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 232,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 117,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 515,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 361,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 62,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 394,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 345,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 360,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 338,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 137,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 233,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 504,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 452,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 278,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 111,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 425,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 406,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 74,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 721,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 544,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 531,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 388,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 241,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 675,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 459,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 119,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 165,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 270,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 483,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 72,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-district-attorney-northern-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 7,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-912",
+      "Name" : "DISTRICT ATTORNEY",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 43,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 23,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 81,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 82,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 51,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 60,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 107,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 66,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 161,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 113,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 122,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 139,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 102,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 114,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 37,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 70,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 167,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 124,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 82,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 26,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 122,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 134,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 239,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 161,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 120,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 133,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 71,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 229,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 124,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 54,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 143,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-district-attorney-northern",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-district-attorney-northern-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-912",
+      "Name" : "DISTRICT ATTORNEY",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 44,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 35,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-dem" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-dem-sheriff-middlesex-county",
+      "ContestSelection" : 
+      [ 
+       { "CandidateIds" : 
+        [ "can-p-j-koutoujian" ],
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-p-j-koutoujian",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 168,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 91,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 323,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 344,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 336,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 270,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 28,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 224,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 293,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 219,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 111,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 480,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 352,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 55,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 377,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 326,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 25,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 344,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 316,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 125,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 229,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 477,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 428,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 272,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 12,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 101,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 404,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 387,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 70,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 696,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 515,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 501,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 363,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 235,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 635,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 444,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 116,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 160,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 260,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 460,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 66,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] },
+       
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-dem-sheriff-middlesex-county-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 4,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 6,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-911",
+      "Name" : "SHERIFF",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 90,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 123,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 66,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 117,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 80,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 40,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 197,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 120,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 140,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 155,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 116,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 135,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 50,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 73,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 193,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 147,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 88,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 36,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 143,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 152,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 264,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 188,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 149,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 158,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 76,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 270,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 138,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 31,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 49,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 62,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 165,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" } ] },
+     
+     { "PrimaryPartyIds" : 
+      [ "par-rep" ],
+      "VotesAllowed" : 1,
+      "@type" : "ElectionResults.CandidateContest",
+      "@id" : "cc-rep-sheriff-middlesex-county",
+      "ContestSelection" : 
+      [ 
+       { "IsWriteIn" : true,
+        "@type" : "ElectionResults.CandidateSelection",
+        "@id" : "cs-rep-sheriff-middlesex-county-wi",
+        "VoteCounts" : 
+        [ 
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-2A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-1-3",
+          "Type" : "total" },
+         
+         { "Count" : 5,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-1",
+          "Type" : "total" },
+         
+         { "Count" : 3,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-2-3A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-3-3A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-1",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-2A",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-4-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-5-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-1A",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-6-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-2A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-7-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-8-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-1",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-2",
+          "Type" : "total" },
+         
+         { "Count" : 2,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-9-3",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-2",
+          "Type" : "total" },
+         
+         { "Count" : 1,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-10-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-1A",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-2",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3",
+          "Type" : "total" },
+         
+         { "Count" : 0,
+          "@type" : "ElectionResults.VoteCounts",
+          "GpUnitId" : "prec-11-3A",
+          "Type" : "total" } ] } ],
+      "ElectionDistrictId" : "ed-911",
+      "Name" : "SHERIFF",
+      "OtherCounts" : 
+      [ 
+       { "GpUnitId" : "prec-1-1",
+        "Undervotes" : 12,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2",
+        "Undervotes" : 19,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-2A",
+        "Undervotes" : 0,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-1-3",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-1",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-2",
+        "Undervotes" : 42,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-2-3A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-1",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-2",
+        "Undervotes" : 13,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3",
+        "Undervotes" : 10,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-3-3A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-1",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-2A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-4-3",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-1",
+        "Undervotes" : 18,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-2",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-5-3",
+        "Undervotes" : 29,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1",
+        "Undervotes" : 17,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-1A",
+        "Undervotes" : 5,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-6-3",
+        "Undervotes" : 32,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-1",
+        "Undervotes" : 20,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2",
+        "Undervotes" : 15,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-2A",
+        "Undervotes" : 1,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-7-3",
+        "Undervotes" : 9,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-1",
+        "Undervotes" : 25,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-2",
+        "Undervotes" : 33,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-8-3",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-1",
+        "Undervotes" : 48,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-2",
+        "Undervotes" : 46,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-9-3",
+        "Undervotes" : 34,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1",
+        "Undervotes" : 28,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-1A",
+        "Undervotes" : 14,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-2",
+        "Undervotes" : 30,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-10-3",
+        "Undervotes" : 27,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1",
+        "Undervotes" : 11,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-1A",
+        "Undervotes" : 8,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-2",
+        "Undervotes" : 21,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3",
+        "Undervotes" : 45,
+        "@type" : "ElectionResults.OtherCounts" },
+       
+       { "GpUnitId" : "prec-11-3A",
+        "Undervotes" : 4,
+        "@type" : "ElectionResults.OtherCounts" } ] } ],
+    "ElectionScopeId" : "loc-cambridge",
+    "EndDate" : "2022-09-06",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "General Election",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "StartDate" : "2022-09-06",
+    "Type" : "primary",
+    "@type" : "ElectionResults.Election" } ],
+  "Format" : "precinct-level",
+  "GeneratedDate" : "2023-05-02T00:00:00Z",
+  "GpUnit" : 
+  [ 
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-1-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 1-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-2-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 2-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-3-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 3-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-4-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 4-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-5-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 5-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-6-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 6-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-2A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-2A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-7-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 7-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-8-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 8-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-9-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 9-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-10-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 10-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-1",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-1 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-1A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-1A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-2",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-2 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-3",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-3 ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "precinct",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "prec-11-3A",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Precinct 11-3A",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "city",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "loc-cambridge",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Cambridge",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "congressional",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-6",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1A",
+     "prec-10-2",
+     "prec-11-3",
+     "prec-3-3A",
+     "prec-4-2",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "FIFTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "congressional",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-8",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-4-1",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-7-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SEVENTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "OtherType" : "gov-council",
+    "Type" : "other",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-14",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "THIRD DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "OtherType" : "gov-council",
+    "Type" : "other",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-17",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SIXTH DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-34",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-7-1",
+     "prec-8-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SECOND MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-141",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-1",
+     "prec-11-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-FOURTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-142",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1A",
+     "prec-10-2",
+     "prec-3-3A",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-FIFTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-143",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-4-1",
+     "prec-5-1",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-SIXTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-146",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-3",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3A",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TWENTY-NINTH MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-185",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-2-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SECOND SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-house",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-201",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-2A",
+     "prec-5-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "EIGHTEENTH SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "county",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-911",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MIDDLESEX COUNTY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "judicial",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-912",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "NORTHERN DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-1311",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MIDDLESEX & SUFFOLK DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "Type" : "state-senate",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "ed-1332",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SUFFOLK & MIDDLESEX DISTRICT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "CONFERENCE CENTER" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-222-jacobs-street",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "222 JACOBS STREET",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "COMMUNITY FLOOR, 85 OXFORD ST, SACRAMENTO ST ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-baldwin-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "BALDWIN SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "50 CHURCHILL AVENUE, COMMUNITY ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-burns-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "BURNS APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "66 SHERMAN STREET, PATIO ENTRANCE ON CADBURY RD" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cadbury-commons",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CADBURY COMMONS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "459 BROADWAY, MEDIA CAFETERIA, CAMBRIDGE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-rindge--latin",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE RINDGE & LATIN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "459 BROADWAY, MEDIA CAFETERIA, CAMBRIDGE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-rindge--latin-",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE RINDGE & LATIN ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "250 FRESH POND PARKWAY" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-water-departmen",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CAMBRIDGE WATER DEPARTMEN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "344 BROADWAY, 2ND FLOOR CONFERENCE ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-city-hall-annex",
+    "ComposingGpUnitIds" : 
+    [ "prec-6-1",
+     "prec-6-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CITY HALL ANNEX",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "795 MASSACHUSETTS AVE, DRIVEWAY ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-city-hall-basement",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-3",
+     "prec-3-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "CITY HALL BASEMENT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "5 LONGFELLOW PARK, COMMUNITY ROOM" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-friends-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "FRIENDS CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "44 LINNAEAN ST., PLAYGROUND ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-graham--parks-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-8-1",
+     "prec-10-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "GRAHAM & PARKS SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "48 QUINCY STREET, CAMBRIDGE ST. ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-gund-hl-harv-design-sch",
+    "ComposingGpUnitIds" : 
+    [ "prec-7-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "GUND HL, HARV DESIGN SCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "167 LEXINGTON AVENUE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-lexington-ave-fire-house",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "LEXINGTON AVE FIRE HOUSE",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "BEHIND STRATTON STUDENT CENTER (70 MASS AVE)" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-mit-kresge-auditorium",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-2",
+     "prec-1-2A",
+     "prec-5-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "M.I.T. KRESGE AUDITORIUM",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "102 PUTNAM AVENUE, PLAYGROUND GYM ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-martin-luther-king-jr-sch",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-3",
+     "prec-8-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MARTIN LUTHER KING JR SCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "15 LAMBERT STREET, CAMBRIDGE ST. ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-millers-river-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MILLERS RIVER APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "40 GRANITE ST, MAIN ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-morse-school",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-1",
+     "prec-5-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MORSE SCHOOL",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "243 HARVARD ST, FRONT ENTRANCE " ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-moses-youth-center-",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "MOSES YOUTH CENTER ",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "48 SIXTH ST, CORNER OF THORNDIKE ST, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-onconnell-branch-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-3",
+     "prec-2-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "O'CONNELL BRANCH LIBRARY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "70 RINDGE AVE, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-peabody-school-gym",
+    "ComposingGpUnitIds" : 
+    [ "prec-10-1",
+     "prec-10-1A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "PEABODY SCHOOL GYM",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "131 WASHINGTON STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-pisani-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-3-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "PISANI CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "170 RINDGE AVENUE, REAR ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-reservoir-church",
+    "ComposingGpUnitIds" : 
+    [ "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "RESERVOIR CHURCH",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "680 HURON AVENUE, SECOND FLOOR" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-russell-youth-center",
+    "ComposingGpUnitIds" : 
+    [ "prec-9-3" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "RUSSELL YOUTH CENTER",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "402 MASSCHUSETTS AVE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-salvation-army",
+    "ComposingGpUnitIds" : 
+    [ "prec-5-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "SALVATION ARMY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "838 MASSACHUSETTS AVE, ENTRANCE ON SELLERS STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-st-peterns-episcopal-chur",
+    "ComposingGpUnitIds" : 
+    [ "prec-4-2",
+     "prec-4-2A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "ST PETER'S EPISCOPAL CHUR",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "25 EIGHTH ST, COMMUNITY ROOM, THORNDIKE STREET ENTRANCE" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-truman-apartments",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-2" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "TRUMAN APARTMENTS",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "826 CAMBRIDGE ST, SIDE ENTRANCE ON BERKSHIRE STREET" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-09-06",
+       "Hours" : 
+       [ 
+        { "EndTime" : "20:00:00-04:00",
+         "StartTime" : "07:00:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-09-06",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "polling-place",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-valente-branch-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-2-1" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "VALENTE BRANCH LIBRARY",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "250 Fresh Pond Parkway" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-cambridge-water-department",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Cambridge Water Department",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "449 Broadway" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-main-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Main Library",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } },
+   
+   { "ContactInformation" : 
+    { "AddressLine" : 
+     [ "826 Cambridge Street, Side Entrance on Berkshire Street" ],
+     "Schedule" : 
+     [ 
+      { "EndDate" : "2022-11-04",
+       "Hours" : 
+       [ 
+        { "Day" : "saturday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "sunday",
+         "EndTime" : "15:00:00-04:00",
+         "StartTime" : "09:00:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "monday",
+         "EndTime" : "20:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "tuesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "wednesday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "thursday",
+         "EndTime" : "17:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" },
+        
+        { "Day" : "friday",
+         "EndTime" : "12:00:00-04:00",
+         "StartTime" : "08:30:00-04:00",
+         "@type" : "ElectionResults.Hours" } ],
+       "StartDate" : "2022-10-22",
+       "@type" : "ElectionResults.Schedule" } ],
+     "@type" : "ElectionResults.ContactInformation" },
+    "IsDistricted" : false,
+    "IsMailOnly" : false,
+    "Type" : "vote-center",
+    "@type" : "ElectionResults.ReportingUnit",
+    "@id" : "pl-valente-library",
+    "ComposingGpUnitIds" : 
+    [ "prec-1-1",
+     "prec-1-2",
+     "prec-1-2A",
+     "prec-1-3",
+     "prec-2-1",
+     "prec-2-2",
+     "prec-2-3",
+     "prec-2-3A",
+     "prec-3-1",
+     "prec-3-2",
+     "prec-3-3",
+     "prec-3-3A",
+     "prec-4-1",
+     "prec-4-2",
+     "prec-4-2A",
+     "prec-4-3",
+     "prec-5-1",
+     "prec-5-2",
+     "prec-5-3",
+     "prec-6-1",
+     "prec-6-1A",
+     "prec-6-2",
+     "prec-6-3",
+     "prec-7-1",
+     "prec-7-2",
+     "prec-7-2A",
+     "prec-7-3",
+     "prec-8-1",
+     "prec-8-2",
+     "prec-8-3",
+     "prec-9-1",
+     "prec-9-2",
+     "prec-9-3",
+     "prec-10-1",
+     "prec-10-1A",
+     "prec-10-2",
+     "prec-10-3",
+     "prec-11-1",
+     "prec-11-1A",
+     "prec-11-2",
+     "prec-11-3",
+     "prec-11-3A" ],
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "Valente Library",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" } } ],
+  "Issuer" : "NIST Test Data",
+  "IssuerAbbreviation" : "NIST",
+  "Party" : 
+  [ 
+   { "@id" : "par-dem",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "DEMOCRAT",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" },
+   
+   { "@id" : "par-rep",
+    "Name" : 
+    { "Text" : 
+     [ 
+      { "Content" : "REPUBLICAN",
+       "Language" : "en",
+       "@type" : "ElectionResults.LanguageString" } ],
+     "@type" : "ElectionResults.InternationalizedText" },
+    "@type" : "ElectionResults.Party" } ],
+  "SequenceEnd" : 1,
+  "SequenceStart" : 1,
+  "Status" : "certified",
+  "VendorApplicationId" : "MA Export",
+  "@type" : "ElectionResults.ElectionReport" }

--- a/test_data/synthetic/gen-01/README.md
+++ b/test_data/synthetic/gen-01/README.md
@@ -449,7 +449,7 @@ voted for the given precinct:**
 
 **Test Results:**
 
-**Precinct 1:**
+**Precinct 1 (4,5,6):**
 
 **Straight Party**
 
@@ -731,7 +731,7 @@ Roland Gustiv 2
 
 Write-In 2
 
-**Precinct 3:**
+**Precinct 3 (7,8,9):**
 
 **Straight Party**
 
@@ -741,7 +741,7 @@ Republican 1
 
 Democrat 1
 
-**Presiden***t*
+**President***
 
 Harry Brown LIB 3
 

--- a/test_data/synthetic/gen-01/bd_v1/bd-gen-01.json
+++ b/test_data/synthetic/gen-01/bd_v1/bd-gen-01.json
@@ -805,7 +805,7 @@
          "@type" : "BallotDefinition.InternationalizedText" },
         "@type" : "BallotDefinition.BallotMeasureOption",
         "@id" : "bm-proposal-1-no" } ],
-      "ElectionDistrictId" : "prec-1",
+      "ElectionDistrictId" : "cp-1-4-5-6",
       "Name" : "Proposal 1 - Road improvements",
       "VoteVariation" : "n-of-m" },
      
@@ -846,7 +846,7 @@
      { "FullText" : 
       { "Text" : 
        [ 
-        { "Content" : "Should the salex tax be increased to 9%",
+        { "Content" : "Should the sales tax be increased to 9%",
          "Language" : "en",
          "@type" : "BallotDefinition.LanguageString" } ],
        "@type" : "BallotDefinition.InternationalizedText" },
@@ -873,7 +873,7 @@
          "@type" : "BallotDefinition.InternationalizedText" },
         "@type" : "BallotDefinition.BallotMeasureOption",
         "@id" : "bm-proposal-3-no" } ],
-      "ElectionDistrictId" : "prec-3",
+      "ElectionDistrictId" : "ps-2b",
       "Name" : "Proposal 3 - Sales tax",
       "VoteVariation" : "n-of-m" },
      
@@ -889,7 +889,7 @@
        
        { "IsWriteIn" : true,
         "@type" : "BallotDefinition.CandidateOption",
-        "@id" : "cs--wi" } ],
+        "@id" : "cs-county-comissioner-1-wi" } ],
       "ElectionDistrictId" : "ru-county-commisioner-1",
       "Name" : "County Commissioner - District 1",
       "VoteVariation" : "n-of-m" },
@@ -1087,7 +1087,13 @@
     "@id" : "ru-congress-1",
     "ComposingGpUnitIds" : 
     [ "prec-1",
-     "prec-3" ],
+     "prec-3",
+     "prec-4",
+     "prec-5",
+     "prec-6",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1115,7 +1121,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-assembly-1",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1143,7 +1152,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-assembly-3",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1157,7 +1169,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-county-commisioner-1",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1185,7 +1200,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-county-commisioner-3",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1199,7 +1217,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-supreme-court-a",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1227,7 +1248,10 @@
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ru-supreme-court-c",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1262,7 +1286,10 @@
     "@id" : "ru-stadium",
     "ComposingGpUnitIds" : 
     [ "ps-2a",
-     "prec-3" ],
+     "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1416,7 +1443,7 @@
        "@type" : "BallotDefinition.LanguageString" } ],
      "@type" : "BallotDefinition.InternationalizedText" } },
    
-   { "Type" : "precinct",
+   { "Type" : "split-precinct",
     "@type" : "BallotDefinition.ReportingUnit",
     "@id" : "ps-2b",
     "Name" : 

--- a/test_data/synthetic/gen-01/bd_v1/bd-gen-01.xml
+++ b/test_data/synthetic/gen-01/bd_v1/bd-gen-01.xml
@@ -509,7 +509,7 @@
 					<Text Language="en">NO</Text>
 				</Selection>
 			</ContestOption>
-			<ElectionDistrictId>prec-1</ElectionDistrictId>
+			<ElectionDistrictId>cp-1-4-5-6</ElectionDistrictId>
 			<Name>Proposal 1 - Road improvements</Name>
 			<VoteVariation>n-of-m</VoteVariation>
 			<FullText>
@@ -545,18 +545,18 @@
 					<Text Language="en">NO</Text>
 				</Selection>
 			</ContestOption>
-			<ElectionDistrictId>prec-3</ElectionDistrictId>
+			<ElectionDistrictId>ps-2b</ElectionDistrictId>
 			<Name>Proposal 3 - Sales tax</Name>
 			<VoteVariation>n-of-m</VoteVariation>
 			<FullText>
-				<Text Language="en">Should the salex tax be increased to 9%</Text>
+				<Text Language="en">Should the sales tax be increased to 9%</Text>
 			</FullText>
 		</Contest>
 		<Contest xsi:type="CandidateContest" ObjectId="cc-county-comissioner-1">
 			<ContestOption xsi:type="CandidateOption" ObjectId="cs-county-comissioner-1-ab">
 				<CandidateIds>can-ab</CandidateIds>
 			</ContestOption>
-			<ContestOption xsi:type="CandidateOption" ObjectId="cs--wi">
+			<ContestOption xsi:type="CandidateOption" ObjectId="cs-county-comissioner-1-wi">
 				<IsWriteIn>1</IsWriteIn>
 			</ContestOption>
 			<ElectionDistrictId>ru-county-commisioner-1</ElectionDistrictId>
@@ -691,7 +691,7 @@
 	</Election>
 	<GeneratedDate>2023-07-14T13:32:09-04:00</GeneratedDate>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-congress-1">
-		<ComposingGpUnitIds>prec-1 prec-3</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-1 prec-3 prec-4 prec-5 prec-6 prec-7 prec-8 prec-9</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">1st Congressional District</Text>
 		</Name>
@@ -707,7 +707,7 @@
 		<Type>congressional</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-assembly-1">
-		<ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">1st Assembly District</Text>
 		</Name>
@@ -723,7 +723,7 @@
 		<Type>state-house</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-assembly-3">
-		<ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">3rd Assembly District</Text>
 		</Name>
@@ -731,7 +731,7 @@
 		<Type>state-house</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-county-commisioner-1">
-		<ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">1st County Commissioner District</Text>
 		</Name>
@@ -747,7 +747,7 @@
 		<Type>county-council</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-county-commisioner-3">
-		<ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">3rd County Commissioner District</Text>
 		</Name>
@@ -755,7 +755,7 @@
 		<Type>county-council</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-supreme-court-a">
-		<ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">Supreme Court Justice - Seat A</Text>
 		</Name>
@@ -771,7 +771,7 @@
 		<Type>judicial</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-supreme-court-c">
-		<ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+		<ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">Supreme Court Justice - Seat C</Text>
 		</Name>
@@ -786,12 +786,13 @@
 		<Type>county</Type>
 	</GpUnit>
 	<GpUnit xsi:type="ReportingUnit" ObjectId="ru-stadium">
-		<ComposingGpUnitIds>ps-2a prec-3</ComposingGpUnitIds>
+		<ComposingGpUnitIds>ps-2a prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
 		<Name>
 			<Text Language="en">Stadium Improvement District</Text>
 		</Name>
 		<Type>special</Type>
 	</GpUnit>
+	<!-- begin split precincts -->
 	<GpUnit xsi:type="ReportingUnit" ObjectId="cp-1-4-5-6">
 		<ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
 		<Name>
@@ -873,7 +874,7 @@
 		<Name>
 			<Text Language="en">Precinct 2b</Text>
 		</Name>
-		<Type>precinct</Type>
+		<Type>split-precinct</Type>
 	</GpUnit>
 	<Issuer>National Institute of Standards and Technology</Issuer>
 	<IssuerAbbreviation>NIST</IssuerAbbreviation>

--- a/test_data/synthetic/gen-01/cvr_v1/cvr-gen-01.json
+++ b/test_data/synthetic/gen-01/cvr_v1/cvr-gen-01.json
@@ -848,7 +848,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1236,7 +1236,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1611,7 +1611,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1817,7 +1817,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -8060,7 +8060,7 @@
        
        { "IsWriteIn" : true,
         "@type" : "CVR.CandidateSelection",
-        "@id" : "cs--wi" } ],
+        "@id" : "cs-county-comissioner-1-wi" } ],
       "Name" : "County Commissioner - District 1",
       "VoteVariation" : "n-of-m" },
      
@@ -8302,7 +8302,7 @@
    
    { "@id" : "ps-2b",
     "Name" : "Precinct 2b",
-    "Type" : "precinct",
+    "Type" : "split-precinct",
     "@type" : "CVR.GpUnit" } ],
   "Party" : 
   [ 

--- a/test_data/synthetic/gen-01/cvr_v1/cvr-gen-01.xml
+++ b/test_data/synthetic/gen-01/cvr_v1/cvr-gen-01.xml
@@ -725,7 +725,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -1067,7 +1067,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -1397,7 +1397,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -1580,7 +1580,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -6999,7 +6999,7 @@
                            xsi:type="CandidateSelection">
             <CandidateIds>can-ab</CandidateIds>
          </ContestSelection>
-         <ContestSelection ObjectId="cs--wi"
+         <ContestSelection ObjectId="cs-county-comissioner-1-wi"
                            xsi:type="CandidateSelection">
             <IsWriteIn>1</IsWriteIn>
          </ContestSelection>
@@ -7207,7 +7207,7 @@
    </GpUnit>
    <GpUnit ObjectId="ps-2b">
       <Name>Precinct 2b</Name>
-      <Type>precinct</Type>
+      <Type>split-precinct</Type>
    </GpUnit>
    <Party ObjectId="par-dem">
       <Name>Democrat</Name>

--- a/test_data/synthetic/gen-01/cvr_v1/raw-cvr-gen-01.json
+++ b/test_data/synthetic/gen-01/cvr_v1/raw-cvr-gen-01.json
@@ -636,7 +636,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1024,7 +1024,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1399,7 +1399,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -1605,7 +1605,7 @@
        { "ContestId" : "cc-county-comissioner-1",
         "CVRContestSelection" : 
         [ 
-         { "ContestSelectionId" : "cs--wi",
+         { "ContestSelectionId" : "cs-county-comissioner-1-wi",
           "OptionPosition" : 2,
           "SelectionPosition" : 
           [ 
@@ -7212,7 +7212,7 @@
        
        { "IsWriteIn" : true,
         "@type" : "CVR.CandidateSelection",
-        "@id" : "cs--wi" } ],
+        "@id" : "cs-county-comissioner-1-wi" } ],
       "Name" : "County Commissioner - District 1",
       "VoteVariation" : "n-of-m" },
      
@@ -7454,7 +7454,7 @@
    
    { "@id" : "ps-2b",
     "Name" : "Precinct 2b",
-    "Type" : "precinct",
+    "Type" : "split-precinct",
     "@type" : "CVR.GpUnit" } ],
   "Party" : 
   [ 

--- a/test_data/synthetic/gen-01/cvr_v1/raw-cvr-gen-01.xml
+++ b/test_data/synthetic/gen-01/cvr_v1/raw-cvr-gen-01.xml
@@ -551,7 +551,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -893,7 +893,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -1223,7 +1223,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -1406,7 +1406,7 @@
          <CVRContest>
             <ContestId>cc-county-comissioner-1</ContestId>
             <CVRContestSelection>
-               <ContestSelectionId>cs--wi</ContestSelectionId>
+               <ContestSelectionId>cs-county-comissioner-1-wi</ContestSelectionId>
                <OptionPosition>2</OptionPosition>
                <SelectionPosition>
                   <CVRWriteIn>
@@ -6303,7 +6303,7 @@
                            xsi:type="CandidateSelection">
             <CandidateIds>can-ab</CandidateIds>
          </ContestSelection>
-         <ContestSelection ObjectId="cs--wi"
+         <ContestSelection ObjectId="cs-county-comissioner-1-wi"
                            xsi:type="CandidateSelection">
             <IsWriteIn>1</IsWriteIn>
          </ContestSelection>
@@ -6511,7 +6511,7 @@
    </GpUnit>
    <GpUnit ObjectId="ps-2b">
       <Name>Precinct 2b</Name>
-      <Type>precinct</Type>
+      <Type>split-precinct</Type>
    </GpUnit>
    <Party ObjectId="par-dem">
       <Name>Democrat</Name>

--- a/test_data/synthetic/gen-01/err_v2/err-gen-01.json
+++ b/test_data/synthetic/gen-01/err_v2/err-gen-01.json
@@ -1598,7 +1598,7 @@
        
        { "IsWriteIn" : true,
         "@type" : "ElectionResults.CandidateSelection",
-        "@id" : "cs--wi",
+        "@id" : "cs-county-comissioner-1-wi",
         "VoteCounts" : 
         [ 
          { "Count" : 4,
@@ -2545,7 +2545,7 @@
        "@type" : "ElectionResults.LanguageString" } ],
      "@type" : "ElectionResults.InternationalizedText" } },
    
-   { "Type" : "precinct",
+   { "Type" : "split-precinct",
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ps-2b",
     "Name" : 

--- a/test_data/synthetic/gen-01/err_v2/err-gen-01.xml
+++ b/test_data/synthetic/gen-01/err_v2/err-gen-01.xml
@@ -1293,7 +1293,7 @@
             </VoteCounts>
             <CandidateIds>can-ab</CandidateIds>
          </ContestSelection>
-         <ContestSelection ObjectId="cs--wi"
+         <ContestSelection ObjectId="cs-county-comissioner-1-wi"
                            xsi:type="CandidateSelection">
             <VoteCounts>
                <GpUnitId>ru-county-1</GpUnitId>
@@ -2134,7 +2134,7 @@
       <Name>
          <Text Language="en-us">Precinct 2b</Text>
       </Name>
-      <Type>precinct</Type>
+      <Type>split-precinct</Type>
    </GpUnit>
    <Issuer>National Institute of Standards and Technology</Issuer>
    <IssuerAbbreviation>NIST</IssuerAbbreviation>

--- a/test_data/synthetic/gen-01/err_v2/pe-err-gen-01.json
+++ b/test_data/synthetic/gen-01/err_v2/pe-err-gen-01.json
@@ -789,7 +789,7 @@
          "@type" : "ElectionResults.InternationalizedText" },
         "@type" : "ElectionResults.BallotMeasureSelection",
         "@id" : "bm-proposal-1-no" } ],
-      "ElectionDistrictId" : "prec-1",
+      "ElectionDistrictId" : "cp-1-4-5-6",
       "Name" : "Proposal 1 - Road improvements",
       "VoteVariation" : "n-of-m" },
      
@@ -830,7 +830,7 @@
      { "FullText" : 
       { "Text" : 
        [ 
-        { "Content" : "Should the salex tax be increased to 9%",
+        { "Content" : "Should the sales tax be increased to 9%",
          "Language" : "en",
          "@type" : "ElectionResults.LanguageString" } ],
        "@type" : "ElectionResults.InternationalizedText" },
@@ -857,7 +857,7 @@
          "@type" : "ElectionResults.InternationalizedText" },
         "@type" : "ElectionResults.BallotMeasureSelection",
         "@id" : "bm-proposal-3-no" } ],
-      "ElectionDistrictId" : "prec-3",
+      "ElectionDistrictId" : "ps-2b",
       "Name" : "Proposal 3 - Sales tax",
       "VoteVariation" : "n-of-m" },
      
@@ -873,7 +873,7 @@
        
        { "IsWriteIn" : true,
         "@type" : "ElectionResults.CandidateSelection",
-        "@id" : "cs--wi" } ],
+        "@id" : "cs-county-comissioner-1-wi" } ],
       "ElectionDistrictId" : "ru-county-commisioner-1",
       "Name" : "County Commissioner - District 1",
       "VoteVariation" : "n-of-m" },
@@ -1072,7 +1072,13 @@
     "@id" : "ru-congress-1",
     "ComposingGpUnitIds" : 
     [ "prec-1",
-     "prec-3" ],
+     "prec-3",
+     "prec-4",
+     "prec-5",
+     "prec-6",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1100,7 +1106,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-assembly-1",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1128,7 +1137,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-assembly-3",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1142,7 +1154,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-county-commisioner-1",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1170,7 +1185,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-county-commisioner-3",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1184,7 +1202,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-supreme-court-a",
     "ComposingGpUnitIds" : 
-    [ "prec-1" ],
+    [ "prec-1",
+     "prec-4",
+     "prec-5",
+     "prec-6" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1212,7 +1233,10 @@
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ru-supreme-court-c",
     "ComposingGpUnitIds" : 
-    [ "prec-3" ],
+    [ "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1247,7 +1271,10 @@
     "@id" : "ru-stadium",
     "ComposingGpUnitIds" : 
     [ "ps-2a",
-     "prec-3" ],
+     "prec-3",
+     "prec-7",
+     "prec-8",
+     "prec-9" ],
     "Name" : 
     { "Text" : 
      [ 
@@ -1401,7 +1428,7 @@
        "@type" : "ElectionResults.LanguageString" } ],
      "@type" : "ElectionResults.InternationalizedText" } },
    
-   { "Type" : "precinct",
+   { "Type" : "split-precinct",
     "@type" : "ElectionResults.ReportingUnit",
     "@id" : "ps-2b",
     "Name" : 

--- a/test_data/synthetic/gen-01/err_v2/pe-err-gen-01.xml
+++ b/test_data/synthetic/gen-01/err_v2/pe-err-gen-01.xml
@@ -544,7 +544,7 @@
                <Text Language="en">NO</Text>
             </Selection>
          </ContestSelection>
-         <ElectionDistrictId>prec-1</ElectionDistrictId>
+         <ElectionDistrictId>cp-1-4-5-6</ElectionDistrictId>
          <Name>Proposal 1 - Road improvements</Name>
          <VoteVariation>n-of-m</VoteVariation>
          <FullText>
@@ -586,11 +586,11 @@
                <Text Language="en">NO</Text>
             </Selection>
          </ContestSelection>
-         <ElectionDistrictId>prec-3</ElectionDistrictId>
+         <ElectionDistrictId>ps-2b</ElectionDistrictId>
          <Name>Proposal 3 - Sales tax</Name>
          <VoteVariation>n-of-m</VoteVariation>
          <FullText>
-            <Text Language="en">Should the salex tax be increased to 9%</Text>
+            <Text Language="en">Should the sales tax be increased to 9%</Text>
          </FullText>
       </Contest>
       <Contest xsi:type="CandidateContest"
@@ -599,7 +599,7 @@
                            xsi:type="CandidateSelection">
             <CandidateIds>can-ab</CandidateIds>
          </ContestSelection>
-         <ContestSelection ObjectId="cs--wi"
+         <ContestSelection ObjectId="cs-county-comissioner-1-wi"
                            xsi:type="CandidateSelection">
             <IsWriteIn>1</IsWriteIn>
          </ContestSelection>
@@ -769,7 +769,7 @@
    <GeneratedDate>2023-07-14T13:32:09-04:00</GeneratedDate>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-congress-1">
-      <ComposingGpUnitIds>prec-1 prec-3</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-1 prec-3 prec-4 prec-5 prec-6 prec-7 prec-8 prec-9</ComposingGpUnitIds>
       <Name>
          <Text Language="en">1st Congressional District</Text>
       </Name>
@@ -787,7 +787,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-assembly-1">
-      <ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
       <Name>
          <Text Language="en">1st Assembly District</Text>
       </Name>
@@ -805,7 +805,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-assembly-3">
-      <ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
       <Name>
          <Text Language="en">3rd Assembly District</Text>
       </Name>
@@ -814,7 +814,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-county-commisioner-1">
-      <ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
       <Name>
          <Text Language="en">1st County Commissioner District</Text>
       </Name>
@@ -832,7 +832,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-county-commisioner-3">
-      <ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
       <Name>
          <Text Language="en">3rd County Commissioner District</Text>
       </Name>
@@ -841,7 +841,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-supreme-court-a">
-      <ComposingGpUnitIds>prec-1</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-1 prec-4 prec-5 prec-6</ComposingGpUnitIds>
       <Name>
          <Text Language="en">Supreme Court Justice - Seat A</Text>
       </Name>
@@ -859,7 +859,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-supreme-court-c">
-      <ComposingGpUnitIds>prec-3</ComposingGpUnitIds>
+      <ComposingGpUnitIds>prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
       <Name>
          <Text Language="en">Supreme Court Justice - Seat C</Text>
       </Name>
@@ -876,7 +876,7 @@
    </GpUnit>
    <GpUnit xsi:type="ReportingUnit"
            ObjectId="ru-stadium">
-      <ComposingGpUnitIds>ps-2a prec-3</ComposingGpUnitIds>
+      <ComposingGpUnitIds>ps-2a prec-3 prec-7 prec-8 prec-9</ComposingGpUnitIds>
       <Name>
          <Text Language="en">Stadium Improvement District</Text>
       </Name>
@@ -974,7 +974,7 @@
       <Name>
          <Text Language="en">Precinct 2b</Text>
       </Name>
-      <Type>precinct</Type>
+      <Type>split-precinct</Type>
    </GpUnit>
    <Issuer>National Institute of Standards and Technology</Issuer>
    <IssuerAbbreviation>NIST</IssuerAbbreviation>

--- a/testcdf.bat
+++ b/testcdf.bat
@@ -4,7 +4,7 @@ setlocal
 
 IF NOT "%2"=="-silent" (
 ECHO NIST Voting 🗳️  Program - Common Data Format Test Method
-ECHO Version 1.0.0 using...
+ECHO Version 1.0.1 using...
 )
 where java >nul 2>nul
 if %errorlevel%==1 (

--- a/testcdf.sh
+++ b/testcdf.sh
@@ -4,7 +4,7 @@ CURRENT_SCRIPT=$0
 if [ "$2" != "-silent" ]
 then
     echo NIST Voting 🗳️  Program - Common Data Format Test Method
-     echo Version 1.0.0 using...
+     echo Version 1.0.1 using...
 fi
 MORGANA_HOME=$(dirname $CURRENT_SCRIPT)
 MORGANA_LIB=$MORGANA_HOME/libraries/*


### PR DESCRIPTION
- Add missing precincts missing in contests that appear under precinct 1, precinct 3
- Categorize `ps-2b` as `split-precinct`
- Update ElectionDistrictId for Proposal 1, 3
- Rename `cs--wi` to `cs-county-comissioner-1-wi` in line with others
- Clarify combined precincts in test results
- Add JSON equivelents for Massachusets test dataset